### PR TITLE
Fix SSH session shell handling

### DIFF
--- a/src/session-manager.js
+++ b/src/session-manager.js
@@ -82,10 +82,11 @@ class SSHSession {
       // Wait for shell prompt
       await this.waitForPrompt();
       
+      // Allow context queries through standard execute flow
+      this.state = SESSION_STATES.READY;
+      
       // Get initial working directory
       await this.updateContext();
-      
-      this.state = SESSION_STATES.READY;
       
       logger.info(`Session ${this.id} initialized`, {
         server: this.serverName,


### PR DESCRIPTION
## Summary
- fix `ssh_session_start` by exposing `SSHManager.requestShell()` and reusing it inside the session manager
- route ssh2 handshake / host-verification logs through the logger so the MCP stdio transport no longer receives stray stdout output
- mark sessions as READY before running `updateContext()` to avoid “session is not ready” warnings while collecting pwd/env

## Reproduction
1. Configure a password-only remote server in `ssh-config.toml`.
2. Call `ssh_session_start` via MCP — the tool crashes with `this.ssh.requestShell is not a function`.
3. Clients that depend on clean stdio (OpenAI Codex CLI / Claude Desktop) immediately close the transport once ssh2 prints its colored host-key messages.
4. If the shell does survive, `updateContext()` still fails because the session state never left INITIALIZING.

## Fix
- add `SSHManager.requestShell()` and invoke it from the session manager’s `initialize()` method
- send handshake / host key logs to the structured logger instead of `console.log`
- switch the session state to READY before collecting context so `updateContext()` can call `execute()` safely

## Testing
- npm test
- Manual: `ssh_session_start` + `ssh_session_send pwd` now succeeds against the remote server used for verification
