### PR TITLE
fix: cross-platform Node wrapper for ssh-manager CLI (#22)

### DIFF
--- a/cli/ssh-manager.js
+++ b/cli/ssh-manager.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Cross-platform entry point for the `ssh-manager` CLI.
+//
+// The real CLI is implemented as a Bash script (cli/ssh-manager). On Unix-like
+// systems we simply forward to it. On Windows, npm cannot create a usable shim
+// for a Bash shebang, so this Node wrapper locates a usable Bash interpreter
+// (Git Bash, WSL, or a bash on PATH) and invokes the script with the correct
+// path conversion.
+//
+// See: https://github.com/bvisible/mcp-ssh-manager/issues/22
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { platform } from 'node:os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const bashScript = resolve(__dirname, 'ssh-manager');
+
+if (!existsSync(bashScript)) {
+  console.error(`[ssh-manager] Unable to locate CLI script at: ${bashScript}`);
+  process.exit(1);
+}
+
+const isWindows = platform() === 'win32';
+const args = process.argv.slice(2);
+
+/**
+ * Convert a Windows-style path (C:\foo\bar) into a POSIX-style path
+ * understood by Git Bash / MSYS (/c/foo/bar). Leaves non-Windows paths alone.
+ */
+function toPosixPath(winPath) {
+  const match = /^([A-Za-z]):[\\/](.*)$/.exec(winPath);
+  if (!match) return winPath.replace(/\\/g, '/');
+  const drive = match[1].toLowerCase();
+  const rest = match[2].replace(/\\/g, '/');
+  return `/${drive}/${rest}`;
+}
+
+/**
+ * Convert a Windows-style path into a WSL-style path (/mnt/c/foo/bar).
+ */
+function toWslPath(winPath) {
+  const match = /^([A-Za-z]):[\\/](.*)$/.exec(winPath);
+  if (!match) return winPath.replace(/\\/g, '/');
+  const drive = match[1].toLowerCase();
+  const rest = match[2].replace(/\\/g, '/');
+  return `/mnt/${drive}/${rest}`;
+}
+
+/**
+ * Try to locate a Git Bash executable on Windows.
+ * Returns an absolute path or null if none is found.
+ */
+function findGitBash() {
+  const candidates = [
+    process.env.ProgramFiles && join(process.env.ProgramFiles, 'Git', 'bin', 'bash.exe'),
+    process.env['ProgramFiles(x86)'] && join(process.env['ProgramFiles(x86)'], 'Git', 'bin', 'bash.exe'),
+    process.env.LOCALAPPDATA && join(process.env.LOCALAPPDATA, 'Programs', 'Git', 'bin', 'bash.exe'),
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+    'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Check whether WSL is available by running `wsl.exe --status`.
+ */
+function hasWsl() {
+  try {
+    const result = spawnSync('wsl.exe', ['--status'], { stdio: 'ignore' });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check whether `bash` is on PATH (covers Unix and some Windows setups).
+ */
+function hasBashOnPath() {
+  const probe = isWindows ? 'where' : 'which';
+  try {
+    const result = spawnSync(probe, ['bash'], { stdio: 'ignore' });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function runUnix() {
+  const result = spawnSync('bash', [bashScript, ...args], {
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    console.error(`[ssh-manager] Failed to execute bash: ${result.error.message}`);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 0);
+}
+
+function runWindows() {
+  // 1. Prefer Git Bash — it understands MSYS-style paths natively.
+  const gitBash = findGitBash();
+  if (gitBash) {
+    const posixScript = toPosixPath(bashScript);
+    const result = spawnSync(gitBash, [posixScript, ...args], {
+      stdio: 'inherit',
+    });
+    if (result.error) {
+      console.error(`[ssh-manager] Failed to run Git Bash: ${result.error.message}`);
+      process.exit(1);
+    }
+    process.exit(result.status ?? 0);
+  }
+
+  // 2. Fall back to WSL — the script lives on the Windows filesystem, so we
+  //    translate C:\... into /mnt/c/... before invoking it.
+  if (hasWsl()) {
+    const wslScript = toWslPath(bashScript);
+    const result = spawnSync('wsl.exe', ['bash', wslScript, ...args], {
+      stdio: 'inherit',
+    });
+    if (result.error) {
+      console.error(`[ssh-manager] Failed to run WSL bash: ${result.error.message}`);
+      process.exit(1);
+    }
+    process.exit(result.status ?? 0);
+  }
+
+  // 3. Last resort: a `bash` on PATH (e.g. custom MSYS2 install).
+  if (hasBashOnPath()) {
+    const result = spawnSync('bash', [bashScript, ...args], {
+      stdio: 'inherit',
+    });
+    if (result.error) {
+      console.error(`[ssh-manager] Failed to run bash: ${result.error.message}`);
+      process.exit(1);
+    }
+    process.exit(result.status ?? 0);
+  }
+
+  // Nothing worked — print an actionable message.
+  console.error(`
+[ssh-manager] No compatible Bash interpreter was found on this Windows system.
+
+The \`ssh-manager\` CLI is implemented as a Bash script and requires one of:
+
+  1. Git for Windows (recommended)
+     Download: https://git-scm.com/download/win
+     This ships a Git Bash that \`ssh-manager\` can use transparently.
+
+  2. Windows Subsystem for Linux (WSL)
+     Install with: wsl --install
+     Then re-run \`ssh-manager\`.
+
+Note: the MCP server itself (\`mcp-ssh-manager\`) is pure Node.js and works on
+Windows without any of the above. Only the interactive \`ssh-manager\` CLI
+needs a Bash environment.
+`);
+  process.exit(1);
+}
+
+if (isWindows) {
+  runWindows();
+} else {
+  runUnix();
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "bin": {
     "mcp-ssh-manager": "src/index.js",
-    "ssh-manager": "cli/ssh-manager"
+    "ssh-manager": "cli/ssh-manager.js"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Fixes #22 — on native Windows shells (PowerShell, cmd) the `ssh-manager` CLI failed immediately after a global install because npm cannot wrap a Bash-shebang script properly: the generated `.ps1`/`.cmd` shim tried to run `/bin/bash.exe`, and even when a bash was on PATH, Windows paths (`C:\...`) were not translated into POSIX form so the script could not be located.

This PR replaces the `ssh-manager` bin entry with a small cross-platform Node wrapper that delegates to the existing Bash CLI. **No Bash code was touched** — the 2500-line CLI keeps running unchanged on Unix.

## What the wrapper does

- **On Unix** — forwards argv to `cli/ssh-manager` via `bash` (zero behavior change).
- **On Windows**, probes in order:
  1. **Git Bash** — looks in `%ProgramFiles%\Git\bin\bash.exe`, `%ProgramFiles(x86)%`, `%LOCALAPPDATA%\Programs\Git\bin\bash.exe`, and two hard-coded defaults. Paths are converted to MSYS form (`C:\foo` → `/c/foo`) before invocation.
  2. **WSL** — detected via `wsl.exe --status`; script path is converted to `/mnt/c/...` and launched via `wsl.exe bash ...`.
  3. **`bash` on PATH** — last resort (custom MSYS2 installs, etc.).
- If none of the three are available, prints an actionable message with links to Git for Windows and instructions for `wsl --install`, and exits 1.

The MCP server itself (`mcp-ssh-manager` → `src/index.js`) is untouched and continues to work on Windows with zero dependencies on Bash.

## Files changed

- `cli/ssh-manager.js` **(new)** — Node wrapper, ESM, no external deps.
- `package.json` — `bin.ssh-manager` now points at `cli/ssh-manager.js` instead of `cli/ssh-manager`.

## How to test

### Unix (should behave exactly as before)
```bash
npm install
node cli/ssh-manager.js --version
node cli/ssh-manager.js --help
node cli/ssh-manager.js server list
```

### Windows (PowerShell / cmd)
```powershell
# From a local clone
npm install -g .

# Then in a fresh shell
ssh-manager --version
ssh-manager --help
ssh-manager server add
```

Expected:
- With **Git for Windows** installed → commands run transparently via Git Bash.
- With **WSL** installed (and no Git Bash) → commands run via `wsl.exe bash`.
- With neither → a clear error message explaining how to install Git for Windows or WSL.

## Test plan

- [x] `node --check cli/ssh-manager.js` passes
- [x] `./scripts/validate.sh` passes
- [x] `node cli/ssh-manager.js --version` on macOS forwards correctly to the Bash script
- [x] `node cli/ssh-manager.js --help` on macOS forwards correctly (colors, subcommand list preserved)
- [ ] Manual verification on Windows 11 + Git for Windows
- [ ] Manual verification on Windows 11 + WSL only
- [ ] Manual verification on Windows 11 with neither (expect actionable error)

The last three items require a Windows machine — @Eleef opened the original issue and offered to help test, so I'd like to ask them to confirm on their setup before we merge.

Closes #22