### PR TITLE
fix(cli): make rsync optional, require only for `ssh-manager sync` (#22 follow-up)

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -22,7 +22,7 @@ echo
 echo -e "${YELLOW}Checking dependencies...${NC}"
 missing=()
 
-for cmd in ssh rsync; do
+for cmd in ssh; do
     if command -v "$cmd" >/dev/null 2>&1; then
         echo -e "  ${GREEN}✓${NC} $cmd"
     else
@@ -31,7 +31,9 @@ for cmd in ssh rsync; do
     fi
 done
 
-for cmd in jq sshpass; do
+# rsync is only used by `ssh-manager sync`; not bundled with Git Bash on Windows.
+# Treat as optional so the CLI is usable without it.
+for cmd in rsync jq sshpass; do
     if command -v "$cmd" >/dev/null 2>&1; then
         echo -e "  ${GREEN}✓${NC} $cmd"
     else

--- a/cli/lib/config.sh
+++ b/cli/lib/config.sh
@@ -364,34 +364,59 @@ validate_server_name() {
 }
 
 # Check dependencies
+# Only `ssh` is strictly required for the CLI to start.
+# rsync is only needed by `ssh-manager sync`; on Windows + Git Bash it is not
+# bundled by default, so requiring it here would block every other command
+# (server add/list/test, exec, ssh, tunnel...). It is checked lazily by
+# `cmd_sync` instead.
 check_dependencies() {
     local missing=()
-    
+
     # Check for required commands
-    for cmd in ssh rsync; do
+    for cmd in ssh; do
         if ! command -v "$cmd" >/dev/null 2>&1; then
             missing+=("$cmd")
         fi
     done
-    
+
     # Check for optional but recommended commands
     local optional=()
-    for cmd in jq sshpass; do
+    for cmd in rsync jq sshpass; do
         if ! command -v "$cmd" >/dev/null 2>&1; then
             optional+=("$cmd")
         fi
     done
-    
+
     if [ ${#missing[@]} -gt 0 ]; then
         print_error "Missing required dependencies: ${missing[*]}"
         print_info "Please install them and try again"
         return 1
     fi
-    
+
     if [ ${#optional[@]} -gt 0 ]; then
         print_warning "Missing optional dependencies: ${optional[*]}"
-        print_info "Some features may not work without them"
+        print_info "Some features may not work without them (rsync is needed for 'ssh-manager sync')"
     fi
-    
+
+    return 0
+}
+
+# Ensure a specific command is available; print an actionable error if not.
+# Used by commands with feature-specific dependencies (e.g. cmd_sync needs rsync).
+require_command() {
+    local cmd="$1"
+    local feature="${2:-this command}"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        print_error "'$cmd' is required for $feature but was not found on PATH"
+        case "$cmd" in
+            rsync)
+                print_info "Install rsync:"
+                print_info "  • macOS:   brew install rsync"
+                print_info "  • Debian:  sudo apt-get install rsync"
+                print_info "  • Windows: install via MSYS2/Cygwin, or use WSL"
+                ;;
+        esac
+        return 1
+    fi
     return 0
 }

--- a/cli/ssh-manager
+++ b/cli/ssh-manager
@@ -159,11 +159,15 @@ cmd_sync() {
     local server="$2"
     local source="$3"
     local dest="$4"
-    
+
     if [ -z "$direction" ] || [ -z "$server" ] || [ -z "$source" ] || [ -z "$dest" ]; then
         print_error "Usage: ssh-manager sync <push|pull> <server> <source> <destination>"
         return 1
     fi
+
+    # rsync is only required at this point — fail with a clear message
+    # rather than blocking the whole CLI at startup.
+    require_command rsync "ssh-manager sync" || return 1
     
     local host=$(get_server_config "$server" "HOST")
     local user=$(get_server_config "$server" "USER")


### PR DESCRIPTION
## Summary

Follow-up to #22, surfaced while @Eleef was validating the Windows wrapper in #23. After the npm shim was fixed, `server add` (and every other command) still exited at startup with:

```text
Missing required dependencies: rsync
```

`rsync` was in the **required** list of the global `check_dependencies` gate alongside `ssh`, but it is only used by `cmd_sync`. Git for Windows / fresh MSYS2 setups don't ship rsync, so the CLI was unusable on a stock Windows install for users who never intend to call `sync`.

## Changes

- **`cli/lib/config.sh`** — drop `rsync` from the required list, add it to the optional warning. New `require_command <cmd> <feature>` helper prints actionable install hints (macOS / Debian / Windows).
- **`cli/ssh-manager`** — `cmd_sync` now calls `require_command rsync "ssh-manager sync"` so the failure happens at the point of use with a clear message instead of blocking startup.
- **`cli/install.sh`** — same reclassification in the installer's dependency probe (yellow warning, not red blocking error).

Only `ssh` itself remains in the required set.

## Verified locally

Tested on macOS by running the CLI with a stripped PATH that contains `ssh` but **not** `rsync`:

| Command | Before | After |
|---|---|---|
| `ssh-manager --version` | exit 1 — `Missing required dependencies: rsync` | exit 0 |
| `ssh-manager --help` | exit 1 | exit 0 |
| `ssh-manager server list` | exit 1 | exit 0 (yellow warning) |
| `ssh-manager sync push ...` | exit 1, generic message | exit 1, **actionable** message with install hints per OS |

```text
❌ 'rsync' is required for ssh-manager sync but was not found on PATH
ℹ️  Install rsync:
ℹ️    • macOS:   brew install rsync
ℹ️    • Debian:  sudo apt-get install rsync
ℹ️    • Windows: install via MSYS2/Cygwin, or use WSL
```

## Test plan (Windows reviewer)

After #23 is merged (or stacked on this branch), on a stock Git-for-Windows install **without** rsync:

- [ ] `ssh-manager --version` works
- [ ] `ssh-manager --help` works
- [ ] `ssh-manager server add` walks through the prompts to completion
- [ ] `ssh-manager server list` shows the yellow `Missing optional dependencies: rsync ...` line but still lists servers
- [ ] `ssh-manager sync push <server> <src> <dst>` fails with the new actionable error pointing at MSYS2/WSL

## Relation to other PRs

- Complements #23 (Windows CLI wrapper) — that PR fixes the npm shim path; this one fixes the next dependency that bites Windows users right after.
- Closes the residual issue surfaced in #22's discussion.