### PR TITLE
fix(cli): reject hyphens in server names; flag legacy invalid entries (#25)

### DIFF
--- a/cli/commands/server.sh
+++ b/cli/commands/server.sh
@@ -8,7 +8,7 @@ cmd_server_add() {
     # Get server name
     local server_name
     while true; do
-        prompt_input "Server name (e.g., prod1, web-server)" "" "server_name"
+        prompt_input "Server name (e.g., prod1, web_server) — letters, digits, underscore only" "" "server_name"
         if validate_server_name "$server_name"; then
             break
         fi
@@ -81,35 +81,62 @@ cmd_server_add() {
 # List all servers
 cmd_server_list() {
     print_header "SSH Servers"
-    
+
     local servers=($(load_servers))
-    
+
     if [ ${#servers[@]} -eq 0 ]; then
         print_warning "No servers configured"
         print_info "Use 'ssh-manager server add' to add a server"
         return 0
     fi
-    
+
+    # Collect names invisible to the MCP loader (#25) so we can mark them.
+    local invalid_names=()
+    while IFS= read -r n; do
+        [ -n "$n" ] && invalid_names+=("$n")
+    done < <(list_invalid_server_names)
+
     print_table_header "NAME" "HOST" "USER"
-    
+
     for server in "${servers[@]}"; do
         local host=$(get_server_config "$server" "HOST")
         local user=$(get_server_config "$server" "USER")
         local port=$(get_server_config "$server" "PORT")
         local description=$(get_server_config "$server" "DESCRIPTION")
-        
+
         port=${port:-22}
-        
+
         local host_info="$host:$port"
         if [ -n "$description" ]; then
             host_info="$host_info ($description)"
         fi
-        
-        print_table_row "$server" "$host_info" "$user"
+
+        # Mark entries invisible to the MCP loader.
+        local display_name="$server"
+        local is_invalid=0
+        for inv in "${invalid_names[@]}"; do
+            if [ "$inv" = "$server" ]; then
+                is_invalid=1
+                break
+            fi
+        done
+        if [ "$is_invalid" = "1" ]; then
+            display_name="$server  ⚠ invalid"
+        fi
+
+        print_table_row "$display_name" "$host_info" "$user"
     done
-    
+
     echo
     print_info "Total servers: ${#servers[@]}"
+
+    if [ ${#invalid_names[@]} -gt 0 ]; then
+        echo
+        print_warning "${#invalid_names[@]} server(s) have names that are invisible to MCP clients (Claude Code, etc.)"
+        print_info "Names with characters other than letters/digits/underscore produce invalid env vars"
+        print_info "Affected: ${invalid_names[*]}"
+        print_info "Fix: 'ssh-manager server remove <name>' then re-add with a valid name (e.g. replace '-' with '_')"
+    fi
 }
 
 # Test server connection

--- a/cli/lib/config.sh
+++ b/cli/lib/config.sh
@@ -339,28 +339,67 @@ test_ssh_connection() {
 }
 
 # Validate server name
+#
+# Server names are baked into POSIX environment variable names of the form
+# SSH_SERVER_<NAME>_HOST. POSIX env-var names are restricted to letters,
+# digits and underscore — hyphens are NOT valid (issue #25). Allowing them
+# silently produced keys like SSH_SERVER_WEB-SERVER_HOST that the Bash CLI
+# happily wrote and re-read, but the MCP Node loader (which uses a strict
+# /^SSH_SERVER_([A-Z0-9_]+)_HOST$/ regex) silently dropped — so the server
+# appeared in `ssh-manager server list` but Claude Code saw zero servers.
+#
+# We now reject hyphens at the source. If a user pasted in a name with a
+# hyphen, we suggest the underscore equivalent in the error message so the
+# fix is one keystroke away.
 validate_server_name() {
     local name="$1"
-    
+
     # Check if name is empty
     if [ -z "$name" ]; then
         print_error "Server name cannot be empty"
         return 1
     fi
-    
-    # Check for invalid characters
-    if ! [[ "$name" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-        print_error "Server name can only contain letters, numbers, underscore and hyphen"
+
+    # Reject hyphens with a targeted message and a copy-paste suggestion.
+    if [[ "$name" == *-* ]]; then
+        local suggested="${name//-/_}"
+        print_error "Server name cannot contain '-' (POSIX env var names allow only letters, digits, underscore)"
+        print_info "Try '$suggested' instead"
         return 1
     fi
-    
+
+    # Catch any other invalid characters
+    if ! [[ "$name" =~ ^[a-zA-Z0-9_]+$ ]]; then
+        print_error "Server name can only contain letters, digits and underscore"
+        return 1
+    fi
+
     # Check if name starts with a letter
     if ! [[ "$name" =~ ^[a-zA-Z] ]]; then
         print_error "Server name must start with a letter"
         return 1
     fi
-    
+
     return 0
+}
+
+# Detect server entries in .env whose names contain characters that are
+# silently dropped by the MCP Node loader. Used by `server list` to flag
+# legacy entries created before the validation fix in #25.
+# Echoes one invalid name per line.
+list_invalid_server_names() {
+    if [ ! -f "$SSH_MANAGER_ENV" ]; then
+        return 0
+    fi
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^SSH_SERVER_(.+)_HOST= ]]; then
+            local raw="${BASH_REMATCH[1]}"
+            if ! [[ "$raw" =~ ^[A-Za-z0-9_]+$ ]]; then
+                # Lowercase, matching load_servers' output convention
+                printf '%s\n' "$(echo "$raw" | tr '[:upper:]' '[:lower:]')"
+            fi
+        fi
+    done < "$SSH_MANAGER_ENV" | sort -u
 }
 
 # Check dependencies

--- a/cli/lib/menu.sh
+++ b/cli/lib/menu.sh
@@ -80,7 +80,8 @@ wizard_add_server() {
     # Step 1: Server name
     print_subheader "Step 1: Server Identification"
     echo "Choose a short, memorable name for this server."
-    echo "Examples: prod1, web-server, database, staging"
+    echo "Letters, digits and underscore only — no hyphens (POSIX env var rule)."
+    echo "Examples: prod1, web_server, database, staging"
     echo
     
     local server_name


### PR DESCRIPTION
## Summary

Closes #25.

`ssh-manager server add` accepted `web-server` (the prompt itself suggested it as an example), but POSIX environment-variable names disallow hyphens. The CLI happily wrote `SSH_SERVER_WEB-SERVER_HOST=...` to `.env`, then re-read it with a loose regex (`^SSH_SERVER_(.+)_HOST=`), so `server list` showed the entry — but the **MCP Node loader uses a strict** `/^SSH_SERVER_([A-Z0-9_]+)_HOST$/` regex and silently dropped it. Net effect: server visible in the CLI, invisible to Claude Code.

## Reproduction (before this PR)

I built a sandbox `.env` mixing both name styles:

```env
SSH_SERVER_WEB-SERVER_HOST=hyphen.example.com
SSH_SERVER_WEB_SERVER_HOST=underscore.example.com
```

Result on `main`:

```text
Bash CLI  → server list  : 2 entries  (web-server, web_server)
MCP loader (Node)        : 1 entry    (web_server only)
```

Exactly the divergence @alexeibugrov reported.

## Changes

### `cli/lib/config.sh`
- `validate_server_name` rejects `-` explicitly with a **copy-paste suggestion**:
  ```text
  ❌ Server name cannot contain '-' (POSIX env var names allow only letters, digits, underscore)
  ℹ️  Try 'my_host' instead
  ```
- A secondary catch-all rejects any other non-`[A-Za-z0-9_]` character (e.g. `web.server`).
- New helper `list_invalid_server_names` scans `.env` for entries whose names won't pass the MCP loader's strict regex.

### `cli/commands/server.sh`
- Prompt example: `web-server` → `web_server`, with a one-line hint about the allowed character set.
- `cmd_server_list` calls `list_invalid_server_names` and:
  - marks each affected row with `⚠ invalid`
  - prints a follow-up warning block listing the affected names and pointing at the fix (`remove` + re-add)
- Legacy entries remain visible so users can see what to migrate, instead of silently disappearing.

### `cli/lib/menu.sh`
- Same prompt-example fix in the interactive wizard.

## Tested manually

I ran four real tests against the sandbox `.env`:

**A. `server list` flags the legacy `web-server` entry**
```text
NAME                 HOST                           USER
web-server  ⚠ invalid hyphen.example.com:22         alice
web_server           underscore.example.com:22      bob

⚠️ 1 server(s) have names that are invisible to MCP clients (Claude Code, etc.)
ℹ️  Affected: web-server
ℹ️  Fix: 'ssh-manager server remove <name>' then re-add with a valid name (e.g. replace '-' with '_')
```

**B. `server add` rejects `web-server` with the underscore suggestion** — caller can immediately type `web_server` and continue.

**C. `server add` rejects `web.server`** — generic "letters, digits and underscore only" message.

**D. ConfigLoader regression check**
```text
MCP-visible servers: [ 'web_server' ]
```
Loader behaviour is unchanged (this PR fixes input validation, not the loader).

## Test plan for the reporter (@alexeibugrov)

If you have a moment, would you mind verifying on macOS:

```bash
# Install from the PR branch
npm uninstall -g mcp-ssh-manager
npm install -g "github:bvisible/mcp-ssh-manager#fix/server-name-hyphens"

# 1) Try to add a server with a hyphen — should be rejected with a suggestion
ssh-manager server add
# Server name: web-server   ← expect:
#   ❌ Server name cannot contain '-' …
#   ℹ️  Try 'web_server' instead
# Then try the suggested 'web_server' — it should be accepted.

# 2) (optional) Check that an already-broken entry is flagged
#    Either reuse your existing ~/.ssh-manager/.env that has SSH_SERVER_WEB-SERVER_*,
#    or create a temp env to test:
cat > /tmp/test.env <<'ENV'
SSH_SERVER_WEB-SERVER_HOST=1.2.3.4
SSH_SERVER_WEB-SERVER_USER=alice
SSH_SERVER_WEB-SERVER_PORT=22
ENV
SSH_MANAGER_ENV=/tmp/test.env ssh-manager server list
# expect: row marked '⚠ invalid' + warning block with the migration hint

# 3) In Claude Code, with a freshly-added 'web_server' (underscore), verify
#    the server now shows up via the MCP tool 'list ssh servers'.
```

Things I'd love to confirm:

- [ ] `web-server` is rejected at input with the suggestion of `web_server`
- [ ] `web_server` is accepted and writes a valid `SSH_SERVER_WEB_SERVER_HOST=...` line
- [ ] Pre-existing `SSH_SERVER_<bad-name>_*` entries surface in `server list` with the `⚠ invalid` marker and the warning block
- [ ] After re-adding with an underscore, the server appears in Claude Code (`list ssh servers`)

Any failure output is appreciated. Thanks again for the very precise bug report — it pointed straight at the regex divergence.