### PR TITLE
fix(windows): platform-aware command execution for Windows OpenSSH targets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -287,6 +287,8 @@ async function execCommandWithTimeout(ssh, command, options = {}, timeoutMs = 30
   }
 
   // For commands that might hang, use the system's timeout command if available
+  // Note: Windows targets already returned above via the PowerShell path, so
+  // this branch is only reached for Linux/macOS targets.
   const useSystemTimeout = timeoutMs > 0 && timeoutMs < 300000 && !rawCommand; // Max 5 minutes, not for raw commands
 
   if (useSystemTimeout) {
@@ -1827,9 +1829,20 @@ registerToolConditional(
           const servers = loadServerConfig();
           const serverConfig = servers[serverName.toLowerCase()];
           const workingDir = cwd || serverConfig?.default_dir;
-          const fullCommand = workingDir ? `cd ${workingDir} && ${command}` : command;
+          const platform = serverConfig?.platform || 'linux';
+          let fullCommand;
+          if (workingDir) {
+            if (platform === 'windows') {
+              const escapedDir = workingDir.replace(/'/g, "''");
+              fullCommand = `Set-Location '${escapedDir}'; ${command}`;
+            } else {
+              fullCommand = `cd ${workingDir} && ${command}`;
+            }
+          } else {
+            fullCommand = command;
+          }
 
-          const execResult = await execCommandWithTimeout(ssh, fullCommand, { platform: serverConfig?.platform }, 30000);
+          const execResult = await execCommandWithTimeout(ssh, fullCommand, { platform }, 30000);
 
           return {
             stdout: execResult.stdout,
@@ -2209,13 +2222,24 @@ registerToolConditional(
       }
 
       // Add working directory if specified
+      const platform = serverConfig?.platform || 'linux';
       if (cwd) {
-        fullCommand = `cd ${cwd} && ${fullCommand}`;
+        if (platform === 'windows') {
+          const escapedDir = cwd.replace(/'/g, "''");
+          fullCommand = `Set-Location '${escapedDir}'; ${fullCommand}`;
+        } else {
+          fullCommand = `cd ${cwd} && ${fullCommand}`;
+        }
       } else if (serverConfig?.default_dir) {
-        fullCommand = `cd ${serverConfig.default_dir} && ${fullCommand}`;
+        if (platform === 'windows') {
+          const escapedDir = serverConfig.default_dir.replace(/'/g, "''");
+          fullCommand = `Set-Location '${escapedDir}'; ${fullCommand}`;
+        } else {
+          fullCommand = `cd ${serverConfig.default_dir} && ${fullCommand}`;
+        }
       }
 
-      const result = await execCommandWithTimeout(ssh, fullCommand, { platform: serverConfig?.platform }, timeout);
+      const result = await execCommandWithTimeout(ssh, fullCommand, { platform }, timeout);
 
       // Mask password in output for security
       const maskedCommand = fullCommand.replace(/echo "[^"]+" \| sudo -S/, 'sudo');

--- a/src/index.js
+++ b/src/index.js
@@ -286,9 +286,12 @@ async function execCommandWithTimeout(ssh, command, options = {}, timeoutMs = 30
     return ssh.execCommand(wrappedCommand, { ...otherOptions, execOptions: { ...(otherOptions.execOptions || {}) } });
   }
 
-  // For commands that might hang, use the system's timeout command if available
-  // Note: Windows targets already returned above via the PowerShell path, so
-  // this branch is only reached for Linux/macOS targets.
+  // For commands that might hang, use the system's timeout command if available.
+  // Note: the `!isWindows` guard that existed here previously is intentionally
+  // removed. Windows targets return early above (the `if (platform === 'windows'
+  // && !rawCommand)` block), so by the time execution reaches this line it is
+  // guaranteed to be a Linux/macOS target. The behaviour is identical; the old
+  // guard was made redundant by the early-return path.
   const useSystemTimeout = timeoutMs > 0 && timeoutMs < 300000 && !rawCommand; // Max 5 minutes, not for raw commands
 
   if (useSystemTimeout) {

--- a/src/index.js
+++ b/src/index.js
@@ -268,12 +268,26 @@ function loadServerConfig() {
 // Execute command with timeout - using child_process timeout for real kill
 async function execCommandWithTimeout(ssh, command, options = {}, timeoutMs = 30000) {
   // Pass through rawCommand and platform if specified
-  const { rawCommand, platform, ...otherOptions } = options;
-  const isWindows = platform === 'windows';
+  const { rawCommand, platform = 'linux', ...otherOptions } = options;
+
+  // Windows targets: encode the command as PowerShell -EncodedCommand (UTF-16
+  // LE base64). This is the standard approach (used by Ansible / Chef / Puppet)
+  // because cmd.exe's quoting rules are inconsistent across versions and break
+  // commands containing $vars, $(...) subexpressions, double-quoted strings,
+  // pipes, etc. Base64 sidesteps all escape issues entirely.
+  if (platform === 'windows' && !rawCommand) {
+    // Suppress progress (avoids CLIXML sentinels in stderr) + force UTF-8 stdout
+    const prelude = `$ProgressPreference='SilentlyContinue'; [Console]::OutputEncoding=[System.Text.Encoding]::UTF8;`;
+    const fullPSCommand = `${prelude} ${command}`;
+    const utf16le = Buffer.from(fullPSCommand, 'utf16le');
+    const b64 = utf16le.toString('base64');
+    // -OutputFormat Text prevents stderr/info streams from being CLIXML-encoded
+    const wrappedCommand = `powershell -NoProfile -OutputFormat Text -EncodedCommand ${b64}`;
+    return ssh.execCommand(wrappedCommand, { ...otherOptions, execOptions: { ...(otherOptions.execOptions || {}) } });
+  }
 
   // For commands that might hang, use the system's timeout command if available
-  // Skip for Windows hosts where the Linux timeout/sh commands don't exist
-  const useSystemTimeout = timeoutMs > 0 && timeoutMs < 300000 && !rawCommand && !isWindows; // Max 5 minutes, not for raw/Windows commands
+  const useSystemTimeout = timeoutMs > 0 && timeoutMs < 300000 && !rawCommand; // Max 5 minutes, not for raw commands
 
   if (useSystemTimeout) {
     // Wrap command with timeout command (works on Linux/Mac)
@@ -617,12 +631,25 @@ registerToolConditional(
       const servers = loadServerConfig();
       const serverConfig = servers[serverName.toLowerCase()];
       const workingDir = cwd || serverConfig?.default_dir;
-      const fullCommand = workingDir ? `cd ${workingDir} && ${expandedCommand}` : expandedCommand;
+      const platform = serverConfig?.platform || 'linux';
+
+      // Build cwd-prefixed command using platform-appropriate syntax
+      let fullCommand;
+      if (workingDir) {
+        if (platform === 'windows') {
+          const escapedDir = workingDir.replace(/'/g, "''");
+          fullCommand = `Set-Location '${escapedDir}'; ${expandedCommand}`;
+        } else {
+          fullCommand = `cd ${workingDir} && ${expandedCommand}`;
+        }
+      } else {
+        fullCommand = expandedCommand;
+      }
 
       // Log command execution
       const startTime = logger.logCommand(serverName, fullCommand, workingDir);
 
-      const result = await execCommandWithTimeout(ssh, fullCommand, { platform: serverConfig?.platform }, cappedTimeout);
+      const result = await execCommandWithTimeout(ssh, fullCommand, { platform }, cappedTimeout);
 
       // Log command result
       logger.logCommandResult(serverName, fullCommand, startTime, result);

--- a/src/index.js
+++ b/src/index.js
@@ -1825,7 +1825,9 @@ registerToolConditional(
         async (serverName) => {
           const ssh = await getConnection(serverName);
 
-          // Build full command with cwd if provided
+          // Build full command with cwd if provided.
+          // Use platform-appropriate syntax: Set-Location for Windows (cmd.exe
+          // does not support `cd && `) vs cd && for Linux/macOS.
           const servers = loadServerConfig();
           const serverConfig = servers[serverName.toLowerCase()];
           const workingDir = cwd || serverConfig?.default_dir;
@@ -1833,6 +1835,7 @@ registerToolConditional(
           let fullCommand;
           if (workingDir) {
             if (platform === 'windows') {
+              // Single-quote escaping: replace ' with '' (PowerShell convention)
               const escapedDir = workingDir.replace(/'/g, "''");
               fullCommand = `Set-Location '${escapedDir}'; ${command}`;
             } else {


### PR DESCRIPTION
## Problem

When connecting to a Windows host via OpenSSH, two issues cause failures:

1. **Encoding (mojibake)**: Commands routed through `cmd.exe` inherit the OEM code page (e.g., CP950 on zh-TW systems), producing garbled output for any non-ASCII content.

2. **`cd &&` syntax error**: `cmd.exe` does not support the `cd /path && command` pattern. When `default_dir` or `cwd` is set, every command fails with a syntax error before even running.

## Solution

Two targeted changes, both gated on `platform = "windows"`. Linux/macOS targets take the existing code path and are **completely unaffected**.

### Patch A — `execCommandWithTimeout`

Wrap the command as `powershell -NoProfile -OutputFormat Text -EncodedCommand <base64>`.

- The payload is UTF-16 LE base64, the standard encoding PowerShell's `-EncodedCommand` expects. This is the same approach used by Ansible, Chef, and Puppet for Windows remote execution — it sidesteps all `cmd.exe` quoting inconsistencies and OEM encoding issues entirely.
- Prepends `$ProgressPreference='SilentlyContinue'` to suppress CLIXML progress sentinels in stderr, and `[Console]::OutputEncoding=UTF8` to force UTF-8 stdout.

### Patch B — cwd handling in `ssh_execute`, `ssh_execute_group`, `ssh_execute_sudo`

Replace `` cd ${workingDir} && `` with `Set-Location '${escapedDir}'; ` for Windows targets. Single-quotes are used and `'` characters in the path are escaped as `''` (PowerShell convention).

### `useSystemTimeout` note

The `!isWindows` guard that previously existed on `useSystemTimeout` is intentionally removed. Windows targets return early via the PowerShell path above, so by the time execution reaches that line it is guaranteed to be a Linux/macOS target. The behaviour is identical; a clarifying comment is added to make this explicit.

## Backward Compatibility

- `platform` defaults to `'linux'` — existing configs without a `platform` field are completely unaffected.
- All three tools (`ssh_execute`, `ssh_execute_group`, `ssh_execute_sudo`) follow the same pattern; no tool is left with the broken `cd &&` syntax for Windows.

## Testing

Tested on Windows 11 with OpenSSH Server enabled, connecting from macOS:

```toml
[ssh_servers.windows-host]
host = "<IP>"
user = "<user>"
key_path = "~/.ssh/id_rsa"
platform = "windows"
default_dir = "C:/Users/<user>"
```

- `ssh_execute` with `default_dir` set → no syntax error ✓
- Chinese filenames and output → no garbled characters ✓
- Linux/macOS servers in the same config → unaffected ✓
- `ssh_execute_group` targeting mixed Linux + Windows servers → both work correctly ✓