### PR TITLE
feat(v3.5.0): per-server security modes — readonly / restricted + audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to MCP SSH Manager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-05-18
+
+### Added
+
+- **Per-server security modes** — opt-in second authorization layer that filters tool invocations and commands *inside* the MCP server, complementing the existing client-side `autoApprove` mechanism. Useful when sharing the MCP with a third-party agent, a CI bot, or any context where you can't fully trust the client. See [docs/SECURITY_MODES.md](docs/SECURITY_MODES.md).
+  - New per-server fields (env: `SSH_SERVER_<N>_MODE`, `SSH_SERVER_<N>_ALLOW_PATTERNS`, `SSH_SERVER_<N>_DENY_PATTERNS`, `SSH_SERVER_<N>_AUDIT_LOG` — TOML: `mode`, `allow_patterns`, `deny_patterns`, `audit_log`).
+  - Three modes: `unrestricted` (default — identical to v3.4.x), `readonly` (blocks mutating tools + built-in destructive command denylist), `restricted` (require regex allowlist + optional denylist, DENY wins over ALLOW).
+  - Gated tools: `ssh_execute`, `ssh_execute_sudo`, `ssh_execute_group`, `ssh_session_send` (command-aware), `ssh_upload`, `ssh_sync`, `ssh_deploy`, `ssh_backup_create`, `ssh_backup_restore`, `ssh_backup_schedule`, `ssh_db_import`, `ssh_db_dump` (tool-level), plus action-gated `ssh_key_manage` (accept/remove), `ssh_alert_setup` (set), `ssh_process_manager` (kill).
+  - Command aliases (`ssh_command_alias`) are expanded **before** policy evaluation, so the denylist can't be bypassed via an alias.
+- **Audit log** — opt-in JSONL trail per server (set `SSH_SERVER_<N>_AUDIT_LOG` to a file path). Records `ts`, `server`, `tool`, sanitized `args`, `allowed`, `reason` (on denial), `exitCode`/`success`/`error` (on execution). Credentials (`password`, `passphrase`, `sudoPassword`, `token`, `secret`, `apikey`) are redacted to `***` even if a tool passes them through args. No log rotation built-in — use `logrotate`.
+- **Interactive wizard prompts** (`ssh-manager server add`) for the three new fields, each with default = skip. Pressing Enter on all three produces an `.env` block identical to v3.4.x output.
+- **New test suite** `tests/test-policy.js` — 26 tests covering the three modes, DENY > ALLOW precedence, invalid regex handling, secret redaction, fail-closed for unknown modes, backward-compat fast path.
+
+### Backward compatibility
+
+- **Zero impact on existing configs.** A v3.4.x `.env` or TOML file loads identically — no `MODE` field means `unrestricted`, and `evaluatePolicy()` early-returns `{ allowed: true }` without compiling a single regex.
+- No new field is mandatory.
+- The audit log file is never created unless `AUDIT_LOG` is explicitly set.
+- `autoApprove` on the Claude Code side keeps working unchanged — the policy intercepts after the client approves, before the SSH command runs, so the client never sees a new prompt.
+- All pre-existing tests (`test-profiles`, `test-command-aliases`, `test-hooks`, `test-tool-registry` — 13 tests) pass without modification.
+
 ## [3.4.1] - 2026-05-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -307,6 +307,28 @@ Edit `~/.config/claude-code/claude_code_config.json`:
 
 For full auto-approval of all SSH tools, see the complete list in [examples/claude-code-config.example.json](examples/claude-code-config.example.json).
 
+### 3.5. Security Modes (Optional, v3.5.0+)
+
+`autoApprove` is all-or-nothing per tool: once `ssh_execute` is approved, anything goes. If you want a **second layer** that filters what the MCP server actually accepts to run — useful when sharing the MCP with a third-party agent, a CI bot, or a client's server — declare a per-server **security mode**.
+
+```bash
+# In your .env — three optional fields. Omit them all to keep v3.4.x behavior exactly.
+SSH_SERVER_CLIENT_PROD_HOST=client-prod.example.com
+SSH_SERVER_CLIENT_PROD_USER=consultant
+SSH_SERVER_CLIENT_PROD_KEYPATH=~/.ssh/consultant_ed25519
+
+SSH_SERVER_CLIENT_PROD_MODE=readonly                          # unrestricted | readonly | restricted
+SSH_SERVER_CLIENT_PROD_AUDIT_LOG=~/.ssh-manager/audit.jsonl   # opt-in JSONL audit trail
+# For mode=restricted, provide an allowlist of regex (DENY wins over ALLOW):
+# SSH_SERVER_CI_ALLOW_PATTERNS="^docker (ps|logs);^kubectl get "
+```
+
+- **`unrestricted`** (default, no field needed) — identical to pre-v3.5.0 behavior. Zero overhead.
+- **`readonly`** — blocks `ssh_upload`, `ssh_deploy`, `ssh_sync`, `ssh_execute_sudo`, backup/db write tools, and built-in destructive commands (`rm`, `mv`, `sudo`, `systemctl restart`, redirects outside `/tmp`, `curl | sh`, …).
+- **`restricted`** — every `ssh_execute` command must match at least one `ALLOW_PATTERNS` regex AND no `DENY_PATTERNS` regex.
+
+Existing configs are unaffected — no field is mandatory, no behavior changes unless you opt in. See **[docs/SECURITY_MODES.md](docs/SECURITY_MODES.md)** for the full reference, recipes, and limitations.
+
 ### 4. Start Using!
 
 In Claude Code, you can now:

--- a/cli/commands/server.sh
+++ b/cli/commands/server.sh
@@ -49,7 +49,29 @@ cmd_server_add() {
     # Get optional description
     local description
     prompt_input "Description (optional)" "" "description"
-    
+
+    # ── Security mode (v3.5.0+) — fully optional, defaults preserve pre-v3.5.0 behavior ──
+    # Pressing Enter on every prompt below produces an .env entry identical to v3.4.1.
+    local mode=""
+    local allow_patterns=""
+    local audit_log=""
+    echo
+    print_info "Security mode (optional — press Enter to skip and keep current behavior)"
+    print_info "  unrestricted = no filter (default, identical to v3.4.x)"
+    print_info "  readonly     = block mutating tools + built-in destructive command denylist"
+    print_info "  restricted   = command must match SSH_SERVER_<N>_ALLOW_PATTERNS"
+    prompt_input "Mode [unrestricted|readonly|restricted]" "unrestricted" "mode"
+    # Normalize empty input to "unrestricted" (preserves pre-v3.5.0 .env output).
+    if [ -z "$mode" ]; then mode="unrestricted"; fi
+
+    if [ "$mode" = "restricted" ]; then
+        print_info "Allow patterns: ';'-separated list of regex (e.g. '^docker (ps|logs);^kubectl get ')"
+        prompt_input "ALLOW_PATTERNS (required for restricted)" "" "allow_patterns"
+    fi
+
+    print_info "Audit log: absolute file path to append a JSONL audit record per tool call"
+    prompt_input "AUDIT_LOG path (optional)" "" "audit_log"
+
     # Show summary
     echo
     print_subheader "Configuration Summary"
@@ -64,10 +86,19 @@ cmd_server_add() {
     if [ -n "$description" ]; then
         print_table_row "Description:" "$description"
     fi
-    
+    if [ "$mode" != "unrestricted" ]; then
+        print_table_row "Mode:" "$mode"
+    fi
+    if [ -n "$allow_patterns" ]; then
+        print_table_row "Allow patterns:" "$allow_patterns"
+    fi
+    if [ -n "$audit_log" ]; then
+        print_table_row "Audit log:" "$audit_log"
+    fi
+
     echo
     if prompt_yes_no "Save this configuration?" "y"; then
-        add_server_to_env "$server_name" "$host" "$user" "$auth_type" "$auth_value" "$port" "$description"
+        add_server_to_env "$server_name" "$host" "$user" "$auth_type" "$auth_value" "$port" "$description" "$mode" "$allow_patterns" "$audit_log"
         
         echo
         if prompt_yes_no "Test connection now?" "y"; then

--- a/cli/lib/config.sh
+++ b/cli/lib/config.sh
@@ -156,6 +156,10 @@ get_server_config() {
 }
 
 # Add server to .env
+#
+# Trailing security-mode args (8-10) are optional and default to "" — when
+# omitted they are not written, preserving exact pre-v3.5.0 output for existing
+# wizard call sites.
 add_server_to_env() {
     local name="$1"
     local host="$2"
@@ -164,15 +168,18 @@ add_server_to_env() {
     local auth_value="$5"
     local port="${6:-22}"
     local description="${7:-}"
-    
+    local mode="${8:-}"
+    local allow_patterns="${9:-}"
+    local audit_log="${10:-}"
+
     local name_upper="$(echo "$name" | tr '[:lower:]' '[:upper:]')"
-    
+
     # Check if server already exists
     if grep -q "^SSH_SERVER_${name_upper}_HOST=" "$SSH_MANAGER_ENV" 2>/dev/null; then
         print_error "Server '$name' already exists"
         return 1
     fi
-    
+
     # Ensure parent directory and .env file exist
     mkdir -p "$(dirname "$SSH_MANAGER_ENV")"
     touch "$SSH_MANAGER_ENV"
@@ -187,18 +194,30 @@ add_server_to_env() {
         echo "SSH_SERVER_${name_upper}_HOST=$host"
         echo "SSH_SERVER_${name_upper}_USER=$user"
         echo "SSH_SERVER_${name_upper}_PORT=$port"
-        
+
         if [ "$auth_type" = "password" ]; then
             echo "SSH_SERVER_${name_upper}_PASSWORD=$auth_value"
         else
             echo "SSH_SERVER_${name_upper}_KEYPATH=$auth_value"
         fi
-        
+
         if [ -n "$description" ]; then
             echo "SSH_SERVER_${name_upper}_DESCRIPTION=\"$description\""
         fi
+
+        # Security mode (v3.5.0+) — only emit non-empty / non-default values to
+        # keep generated .env diff-free for users who skip these prompts.
+        if [ -n "$mode" ] && [ "$mode" != "unrestricted" ]; then
+            echo "SSH_SERVER_${name_upper}_MODE=$mode"
+        fi
+        if [ -n "$allow_patterns" ]; then
+            echo "SSH_SERVER_${name_upper}_ALLOW_PATTERNS=\"$allow_patterns\""
+        fi
+        if [ -n "$audit_log" ]; then
+            echo "SSH_SERVER_${name_upper}_AUDIT_LOG=$audit_log"
+        fi
     } >> "$SSH_MANAGER_ENV"
-    
+
     print_success "Server '$name' added successfully"
 }
 

--- a/debug/test-e2e-policy.js
+++ b/debug/test-e2e-policy.js
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * End-to-end policy + audit test against a real SSH server.
+ *
+ * This script is fully generic — it reads its target from environment
+ * variables and does not hardcode any host. It exercises the v3.5.0
+ * policy code paths (unrestricted / readonly / restricted) and the
+ * audit log writer.
+ *
+ * Usage:
+ *   SSH_E2E_HOST=host.example.com \
+ *   SSH_E2E_USER=tester \
+ *   SSH_E2E_PASSWORD=secret \
+ *   node debug/test-e2e-policy.js
+ *
+ * Alternative auth (SSH key):
+ *   SSH_E2E_HOST=host.example.com \
+ *   SSH_E2E_USER=tester \
+ *   SSH_E2E_KEYPATH=~/.ssh/id_ed25519 \
+ *   [SSH_E2E_PASSPHRASE=...] \
+ *   node debug/test-e2e-policy.js
+ *
+ * Optional:
+ *   SSH_E2E_PORT=22
+ *
+ * The test requires write access to /tmp on the remote host (one tiny
+ * file is created and cleaned up on exit). The audit log is written
+ * locally to /tmp and removed at the end of the run.
+ *
+ * What it asserts:
+ *  - SSH layer not broken by v3.5.0 (real exec returns the expected user)
+ *  - unrestricted mode is a strict no-op (every sample tool allowed,
+ *    no audit file created when AUDIT_LOG is absent)
+ *  - readonly mode blocks rm via the built-in denylist, blocks
+ *    ssh_upload and ssh_execute_sudo at the tool level, and the target
+ *    file truly survives on the remote (refusal is real, not silent)
+ *  - restricted mode enforces ALLOW with DENY-wins precedence
+ *  - audit JSONL is well-formed, has the required fields, records
+ *    denial reasons and execution exit codes
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import SSHManager from '../src/ssh-manager.js';
+import { evaluatePolicy, _clearCompiledCache } from '../src/policy.js';
+import { auditLog, _resetWarnedPaths } from '../src/audit.js';
+
+const G = '\x1b[32m', R = '\x1b[31m', Y = '\x1b[33m', N = '\x1b[0m', C = '\x1b[36m';
+
+let passed = 0, failed = 0;
+function ok(msg) { console.log(`${G}✓${N} ${msg}`); passed++; }
+function fail(msg, err) { console.log(`${R}✗${N} ${msg}\n  ${R}${err}${N}`); failed++; }
+function section(msg) { console.log(`\n${C}━━ ${msg} ━━${N}`); }
+
+const HOST = process.env.SSH_E2E_HOST;
+const USER = process.env.SSH_E2E_USER;
+const PORT = parseInt(process.env.SSH_E2E_PORT || '22');
+const PASSWORD = process.env.SSH_E2E_PASSWORD;
+const KEYPATH = process.env.SSH_E2E_KEYPATH;
+const PASSPHRASE = process.env.SSH_E2E_PASSPHRASE;
+
+if (!HOST || !USER || (!PASSWORD && !KEYPATH)) {
+  console.error(`${R}Missing required env vars.${N}`);
+  console.error('Required: SSH_E2E_HOST, SSH_E2E_USER, and either SSH_E2E_PASSWORD or SSH_E2E_KEYPATH');
+  console.error('See the file header for full usage.');
+  process.exit(2);
+}
+
+const AUDIT_PATH = `/tmp/ssh-audit-e2e-${process.pid}.jsonl`;
+const REMOTE_TEST_FILE = `/tmp/policy-test-${process.pid}`;
+
+function expandHome(p) {
+  if (!p) return p;
+  return p.startsWith('~') ? path.join(os.homedir(), p.slice(1)) : p;
+}
+
+function makeConfig(name, mode, extra = {}) {
+  return {
+    name,
+    host: HOST,
+    user: USER,
+    password: PASSWORD,
+    keyPath: expandHome(KEYPATH),
+    passphrase: PASSPHRASE,
+    port: PORT,
+    mode,
+    allowPatterns: extra.allowPatterns || [],
+    denyPatterns: extra.denyPatterns || [],
+    auditLog: extra.auditLog,
+    source: 'e2e-test',
+  };
+}
+
+// One real connection, reused across all modes. The unrestricted smoke test
+// proves it works end-to-end; subsequent mode tests reuse it for actual SSH
+// execution (policy is evaluated in-process before each call).
+const sharedConfig = makeConfig('e2e_shared', 'unrestricted');
+const sharedSSH = new SSHManager(sharedConfig);
+
+async function exitWith(code) {
+  if (fs.existsSync(AUDIT_PATH)) {
+    fs.unlinkSync(AUDIT_PATH);
+    console.log(`${Y}(cleaned up ${AUDIT_PATH})${N}`);
+  }
+  try {
+    if (sharedSSH.connected) {
+      await sharedSSH.execCommand(`rm -f ${REMOTE_TEST_FILE}`, { timeout: 5000 }).catch(() => {});
+      sharedSSH.dispose();
+    }
+  } catch {}
+  process.exit(code);
+}
+
+process.on('SIGINT', () => exitWith(130));
+
+async function main() {
+  console.log(`${Y}E2E policy test against ${USER}@${HOST}:${PORT}${N}`);
+  console.log(`${Y}Audit log: ${AUDIT_PATH}${N}\n`);
+
+  // ── 1. SSH connectivity smoke test ─────────────────────────────────────────
+  section('Smoke: SSH layer not broken by v3.5.0 changes');
+  try {
+    await sharedSSH.connect();
+    const r = await sharedSSH.execCommand('whoami', { timeout: 10000 });
+    if (r.stdout.trim() === USER) {
+      ok(`SSH connect + execCommand returns expected user ("${r.stdout.trim()}")`);
+    } else {
+      fail('whoami output mismatch', `expected "${USER}", got "${r.stdout.trim()}"`);
+    }
+  } catch (err) {
+    fail('SSH connect failed', err.message);
+    return exitWith(1);
+  }
+
+  // ── 2. unrestricted: backward-compat fast path ─────────────────────────────
+  section('Mode: unrestricted (backward-compat — must behave like v3.4.x)');
+  const cfgUnr = makeConfig('e2e_unrestricted', 'unrestricted');
+  for (const [tool, command] of [
+    ['ssh_execute', 'ls /tmp'],
+    ['ssh_execute', 'rm /tmp/nonexistent-policy-test-xyz'],
+    ['ssh_execute_sudo', 'whoami'],
+    ['ssh_upload', null],
+    ['ssh_deploy', null],
+  ]) {
+    const r = evaluatePolicy(cfgUnr, tool, command);
+    if (r.allowed) ok(`unrestricted → ${tool}${command ? ` ("${command}")` : ''} allowed`);
+    else fail(`unrestricted blocked ${tool} — should never happen`, r.reason);
+  }
+  if (!fs.existsSync(AUDIT_PATH)) ok('No audit file created (AUDIT_LOG not set)');
+  else fail('Audit file was created without AUDIT_LOG', 'leak');
+
+  // ── 3. readonly: real exec against target ──────────────────────────────────
+  section('Mode: readonly');
+  _resetWarnedPaths();
+  const cfgRo = makeConfig('e2e_readonly', 'readonly', { auditLog: AUDIT_PATH });
+
+  async function tryExec(serverConfig, toolName, command) {
+    const policy = evaluatePolicy(serverConfig, toolName, command);
+    if (!policy.allowed) {
+      auditLog(serverConfig, toolName, { command }, policy);
+      return { allowed: false, reason: policy.reason };
+    }
+    const result = await sharedSSH.execCommand(command, { timeout: 10000 });
+    auditLog(serverConfig, toolName, { command }, policy, {
+      code: result.code,
+      success: result.code === 0,
+    });
+    return { allowed: true, code: result.code, stdout: result.stdout };
+  }
+
+  {
+    const r = await tryExec(cfgRo, 'ssh_execute', 'ls /tmp');
+    if (r.allowed && r.code === 0) ok('readonly: "ls /tmp" allowed and executed (exit 0)');
+    else fail('readonly: "ls /tmp" should pass', JSON.stringify(r));
+  }
+
+  {
+    const r = await tryExec(cfgRo, 'ssh_execute', `echo policy-test > ${REMOTE_TEST_FILE}`);
+    if (r.allowed && r.code === 0) ok(`readonly: "echo > ${REMOTE_TEST_FILE}" allowed (/tmp whitelisted)`);
+    else fail('readonly: redirect to /tmp should pass', JSON.stringify(r));
+  }
+
+  {
+    const r = await tryExec(cfgRo, 'ssh_execute', `rm ${REMOTE_TEST_FILE}`);
+    if (!r.allowed && /rm/.test(r.reason)) ok(`readonly: "rm ${REMOTE_TEST_FILE}" refused (matched rm pattern)`);
+    else fail('readonly: rm should be refused', JSON.stringify(r));
+  }
+
+  {
+    const r = await sharedSSH.execCommand(`test -f ${REMOTE_TEST_FILE} && echo PRESENT || echo ABSENT`, { timeout: 5000 });
+    if (r.stdout.trim() === 'PRESENT') ok('readonly: target file still present on remote (rm truly refused)');
+    else fail('Target file unexpectedly missing', `got "${r.stdout.trim()}"`);
+  }
+
+  {
+    const policy = evaluatePolicy(cfgRo, 'ssh_upload');
+    auditLog(cfgRo, 'ssh_upload', { localPath: '/dev/null', remotePath: '/tmp/x' }, policy);
+    if (!policy.allowed) ok('readonly: ssh_upload refused at tool level');
+    else fail('ssh_upload should be tool-blocked in readonly', JSON.stringify(policy));
+  }
+
+  {
+    const policy = evaluatePolicy(cfgRo, 'ssh_execute_sudo', 'whoami');
+    if (!policy.allowed) ok('readonly: ssh_execute_sudo refused at tool level');
+    else fail('ssh_execute_sudo should be tool-blocked in readonly', JSON.stringify(policy));
+  }
+
+  // ── 4. restricted: ALLOW + DENY ────────────────────────────────────────────
+  section('Mode: restricted');
+  _clearCompiledCache();
+  const cfgRestr = makeConfig('e2e_restricted', 'restricted', {
+    allowPatterns: ['^ls ', '^cat /etc/hostname', '^echo '],
+    denyPatterns: [' -rf', '/etc/passwd'],
+    auditLog: AUDIT_PATH,
+  });
+
+  {
+    const r = await tryExec(cfgRestr, 'ssh_execute', 'ls /tmp');
+    if (r.allowed && r.code === 0) ok('restricted: "ls /tmp" allowed (matches ^ls )');
+    else fail('restricted: ls should pass', JSON.stringify(r));
+  }
+
+  {
+    const r = await tryExec(cfgRestr, 'ssh_execute', 'cat /etc/hostname');
+    if (r.allowed && r.code === 0) ok('restricted: "cat /etc/hostname" allowed (matches ALLOW)');
+    else fail('restricted: cat /etc/hostname should pass', JSON.stringify(r));
+  }
+
+  {
+    const r = await tryExec(cfgRestr, 'ssh_execute', 'cat /etc/passwd');
+    if (!r.allowed && /passwd/.test(r.reason)) ok('restricted: "cat /etc/passwd" refused by DENY');
+    else fail('restricted: cat /etc/passwd should be denied', JSON.stringify(r));
+  }
+
+  {
+    const r = await tryExec(cfgRestr, 'ssh_execute', 'df -h');
+    if (!r.allowed && /ALLOW/.test(r.reason)) ok('restricted: "df -h" refused (no ALLOW match)');
+    else fail('restricted: df should be refused', JSON.stringify(r));
+  }
+
+  // ── 5. audit log integrity ─────────────────────────────────────────────────
+  section('Audit log integrity');
+  if (!fs.existsSync(AUDIT_PATH)) {
+    fail('Audit file was not created', `expected at ${AUDIT_PATH}`);
+  } else {
+    const raw = fs.readFileSync(AUDIT_PATH, 'utf8').trim();
+    const lines = raw.split('\n');
+    ok(`Audit file written with ${lines.length} JSONL lines`);
+
+    let parsed = [];
+    try {
+      parsed = lines.map((l) => JSON.parse(l));
+      ok('Every line is valid JSON');
+    } catch (e) {
+      fail('Audit JSONL parse error', e.message);
+    }
+
+    const required = ['ts', 'server', 'tool', 'args', 'allowed'];
+    if (parsed.every((e) => required.every((f) => f in e))) {
+      ok(`All entries have required fields: ${required.join(', ')}`);
+    } else {
+      fail('Some entries miss required fields', JSON.stringify(parsed[0]));
+    }
+
+    const denials = parsed.filter((e) => !e.allowed);
+    if (denials.length >= 4) ok(`${denials.length} denial entries (≥4 expected)`);
+    else fail('Not enough denials logged', `got ${denials.length}`);
+
+    if (denials.every((e) => typeof e.reason === 'string' && e.reason.length > 0)) {
+      ok('Every denial has a non-empty reason');
+    } else {
+      fail('Some denials missing reason', '');
+    }
+
+    const oks = parsed.filter((e) => e.allowed && typeof e.exitCode === 'number');
+    if (oks.length >= 3) ok(`${oks.length} successful exec entries have exitCode (≥3 expected)`);
+    else fail('Successful entries missing exitCode', `got ${oks.length}`);
+  }
+
+  console.log(`\n${Y}Results:${N}`);
+  console.log(`  ${G}Passed: ${passed}${N}`);
+  console.log(`  ${R}Failed: ${failed}${N}\n`);
+  return exitWith(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(`${R}Unhandled error:${N}`, err);
+  exitWith(2);
+});

--- a/docs/SECURITY_MODES.md
+++ b/docs/SECURITY_MODES.md
@@ -1,0 +1,189 @@
+# Security Modes (v3.5.0+)
+
+`mcp-ssh-manager` lets you declare a **per-server security mode** to constrain
+what an AI agent can do once it's been granted access to the MCP server.
+This is **opt-in** — servers without a `MODE` field behave exactly like they
+did in v3.4.x.
+
+## Why
+
+Before v3.5.0 the only authorization layer was Claude Code's `autoApprove`
+mechanism, which is tool-level and all-or-nothing. Once `ssh_execute` is
+auto-approved, anything goes — including `rm -rf /`. Security modes add a
+**second filter inside the MCP server itself**, so a server you've marked
+`readonly` will refuse destructive commands even if the client allowed
+the tool.
+
+This is **not** a kernel sandbox (no seccomp, no container, no namespaces).
+It's a defense-in-depth filter against accidents and prompt-injection
+attacks, layered between the MCP client and the SSH session.
+
+## The three modes
+
+| Mode | What it does |
+|---|---|
+| `unrestricted` (default) | No filter. Identical to pre-v3.5.0 behavior. Zero overhead — `evaluatePolicy()` early-returns. |
+| `readonly` | Blocks mutating tools at the tool level (`ssh_upload`, `ssh_deploy`, `ssh_sync`, `ssh_execute_sudo`, `ssh_backup_create/restore/schedule`, `ssh_db_import/dump`, `ssh_key_manage` write actions, `ssh_alert_setup` set, `ssh_process_manager kill`). For `ssh_execute` / `ssh_execute_sudo` / `ssh_execute_group` / `ssh_session_send`, applies a built-in denylist (rm, mv, dd, mkfs, chmod, chown, sudo, systemctl restart/stop, docker rm/stop, pipe-to-sh, redirect outside `/tmp`, etc.). |
+| `restricted` | All readonly blocks plus: every command must match at least one `ALLOW_PATTERNS` regex AND no `DENY_PATTERNS` regex. **DENY wins over ALLOW**. With no `ALLOW_PATTERNS`, every command is refused (fail-closed). |
+
+## Configuration
+
+### Environment variables / `.env`
+
+```bash
+SSH_SERVER_PROD_HOST=prod.example.com
+SSH_SERVER_PROD_USER=deploy
+SSH_SERVER_PROD_KEYPATH=~/.ssh/id_ed25519
+
+# Security mode (optional — omit to keep pre-v3.5.0 behavior)
+SSH_SERVER_PROD_MODE=readonly
+SSH_SERVER_PROD_AUDIT_LOG=/var/log/mcp-ssh-prod.jsonl
+
+# For restricted mode
+SSH_SERVER_PROD_ALLOW_PATTERNS="^docker (ps|logs|inspect);^kubectl get ;^systemctl status "
+SSH_SERVER_PROD_DENY_PATTERNS=" -f $; --force"
+```
+
+Patterns are `;`-separated POSIX-ish JavaScript regex (compiled with `new RegExp`).
+Invalid regex are logged as warnings and skipped — they do not abort startup.
+
+### TOML
+
+```toml
+[ssh_servers.prod]
+host = "prod.example.com"
+user = "deploy"
+key_path = "~/.ssh/id_ed25519"
+
+mode = "restricted"
+allow_patterns = ["^docker (ps|logs|inspect)", "^kubectl get ", "^systemctl status "]
+deny_patterns = [" -f $", "--force"]
+audit_log = "/var/log/mcp-ssh-prod.jsonl"
+```
+
+TOML arrays are preferred. A `;`-separated string is also accepted for
+parity with the `.env` form.
+
+## Audit log
+
+When `AUDIT_LOG` (`.env`) or `audit_log` (TOML) is set to a file path, every
+**gated** tool invocation appends a JSONL record:
+
+```json
+{"ts":"2026-05-18T15:30:00.123Z","server":"prod","tool":"ssh_execute","args":{"command":"ls /tmp"},"allowed":true,"exitCode":0,"success":true}
+{"ts":"2026-05-18T15:30:14.789Z","server":"prod","tool":"ssh_execute","args":{"command":"rm /tmp/x"},"allowed":false,"reason":"Command refused on server \"prod\" (mode: readonly): matches built-in destructive pattern /(^|[\\s;&|])rm(\\s|$)/."}
+```
+
+Secrets (`password`, `passphrase`, `sudoPassword`, `token`, `secret`, `apikey`)
+are redacted to `***` before being written, even if a tool somehow passed them
+through args.
+
+Log rotation is not handled by `mcp-ssh-manager` — use `logrotate`, `vector`,
+or your log shipper of choice. v3.5.0 audits cover the gated tool set:
+`ssh_execute`, `ssh_upload`, `ssh_execute_sudo`, plus denials on every other
+mutating tool. Pure read tools (`ssh_health_check`, `ssh_db_query`, `ssh_tail`…)
+are not audited in v3.5.0 — open an issue if you need full coverage.
+
+## Recipes
+
+### Third-party agent with read-only access
+
+Goal: hand the MCP to an external agent (CI bot, sandbox, third-party LLM
+service) that should only be able to **observe** your prod box.
+
+```bash
+SSH_SERVER_PROD_HOST=prod.example.com
+SSH_SERVER_PROD_USER=observer
+SSH_SERVER_PROD_KEYPATH=~/.ssh/observer_ed25519
+SSH_SERVER_PROD_MODE=readonly
+SSH_SERVER_PROD_AUDIT_LOG=~/.ssh-manager/audit/prod.jsonl
+```
+
+The agent can run `ls`, `cat`, `df`, `ps`, `journalctl`, `docker ps`,
+`kubectl get`, etc. — but `rm`, `mv`, `sudo`, redirect-to-`/etc/`, `pipe | sh`,
+`systemctl restart`, `apt install`, etc. all return a `Policy denied` error
+to the MCP client.
+
+### CI bot with a tight allowlist
+
+Goal: an automated bot can only deploy-status commands, nothing else.
+
+```bash
+SSH_SERVER_CI_HOST=ci.example.com
+SSH_SERVER_CI_USER=ci-bot
+SSH_SERVER_CI_KEYPATH=~/.ssh/ci_bot_ed25519
+SSH_SERVER_CI_MODE=restricted
+SSH_SERVER_CI_ALLOW_PATTERNS="^docker compose ps;^docker compose logs ;^/opt/myapp/bin/healthcheck"
+SSH_SERVER_CI_DENY_PATTERNS="--force; rm "
+SSH_SERVER_CI_AUDIT_LOG=/var/log/ci-bot.jsonl
+```
+
+### Mixed fleet: one strict server, others unrestricted
+
+You can mix modes freely — the policy is evaluated per server, per call.
+
+```bash
+# Your dev box — full control, no surprises
+SSH_SERVER_DEV_HOST=dev.local
+SSH_SERVER_DEV_USER=you
+SSH_SERVER_DEV_KEYPATH=~/.ssh/id_ed25519
+# (no MODE → unrestricted, behaves like v3.4.x)
+
+# Client's prod box you don't want to break
+SSH_SERVER_CLIENT_PROD_HOST=client-prod.example.com
+SSH_SERVER_CLIENT_PROD_USER=consultant
+SSH_SERVER_CLIENT_PROD_KEYPATH=~/.ssh/consultant_ed25519
+SSH_SERVER_CLIENT_PROD_MODE=readonly
+SSH_SERVER_CLIENT_PROD_AUDIT_LOG=~/.ssh-manager/audit/client-prod.jsonl
+```
+
+## What gets gated, what doesn't
+
+**Fully gated** (policy check at tool entry):
+`ssh_execute`, `ssh_execute_sudo`, `ssh_execute_group`, `ssh_session_send`,
+`ssh_upload`, `ssh_sync`, `ssh_deploy`, `ssh_backup_create`,
+`ssh_backup_restore`, `ssh_backup_schedule`, `ssh_db_import`, `ssh_db_dump`.
+
+**Action-gated** (only the mutating action is checked):
+`ssh_key_manage` (only `accept` / `remove`), `ssh_alert_setup` (only `set`),
+`ssh_process_manager` (only `kill`).
+
+**Not gated** (pure reads or local-only state — no remote effect to block):
+`ssh_list_servers`, `ssh_download`, `ssh_tail`, `ssh_monitor`, `ssh_history`,
+`ssh_health_check`, `ssh_service_status`, `ssh_db_list`, `ssh_db_query`
+(already SELECT-only), `ssh_backup_list`, `ssh_session_start`,
+`ssh_session_list`, `ssh_session_close`, `ssh_connection_status`,
+`ssh_tunnel_*`, `ssh_group_manage`, `ssh_command_alias`, `ssh_alias`,
+`ssh_hooks`, `ssh_profile`.
+
+## Limitations
+
+- **Not a sandbox.** Once a command is allowed, it runs with the full
+  permissions of the SSH user. Use a dedicated low-privilege account for
+  servers in `readonly` / `restricted` mode.
+- **Regex-based filtering can be bypassed** with creative command crafting
+  (encoded payloads, indirection via shell variables, etc.). Treat `readonly`
+  as protection against accidents and prompt injection of the common form,
+  not as an unbreakable shell escape.
+- **Aliases are expanded before policy evaluation** — you can't bypass a DENY
+  by hiding `rm` behind an alias defined via `ssh_command_alias`.
+- **No transport-level / per-client policies.** All clients see the same
+  policy for a given server. If you need different policies per agent, run
+  separate MCP server instances with different config files.
+
+## Backward compatibility
+
+A v3.4.x `.env` or TOML loads identically under v3.5.0:
+
+- No `MODE` field → `mode = 'unrestricted'` → `evaluatePolicy()` early-returns
+  `{ allowed: true }`. Not a single regex is compiled, not a single byte is
+  written to disk.
+- `AUDIT_LOG` is opt-in — no log file is created until you set it.
+- The interactive wizard (`ssh-manager server add`) defaults all three new
+  prompts to "skip" (press Enter and the resulting `.env` block is identical
+  to v3.4.x).
+- Tool auto-approval (`autoApprove` in `claude_code_config.json`) keeps
+  working — the policy intercepts AFTER auto-approval, BEFORE execution,
+  so the client never sees a new prompt.
+
+See `CHANGELOG.md` v3.5.0 for the full diff.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-ssh-manager",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "MCP SSH Manager: Model Context Protocol server for SSH remote server management. Control SSH connections from Claude Code and OpenAI Codex - execute commands, transfer files, database operations, backups, health monitoring, and DevOps automation. NEW: Tool activation system reduces context usage by 92%",
   "main": "src/index.js",
   "bin": {
@@ -13,11 +13,12 @@
     "setup": "npm install && pip install -r tools/requirements.txt",
     "configure": "python tools/server-manager.py",
     "test-connection": "python tools/test-connection.py",
-    "test": "npm run test:profiles && npm run test:aliases && npm run test:hooks && npm run test:tools",
+    "test": "npm run test:profiles && npm run test:aliases && npm run test:hooks && npm run test:tools && npm run test:policy",
     "test:profiles": "node tests/test-profiles.js",
     "test:aliases": "node tests/test-command-aliases.js",
     "test:hooks": "node tests/test-hooks.js",
     "test:tools": "node tests/test-tool-registry.js",
+    "test:policy": "node tests/test-policy.js",
     "test:all": "npm test && ./scripts/validate.sh",
     "validate": "./scripts/validate.sh",
     "lint": "eslint src/*.js",

--- a/src/audit.js
+++ b/src/audit.js
@@ -1,0 +1,97 @@
+/**
+ * Per-server append-only audit log.
+ *
+ * Activated only when a server's config has AUDIT_LOG (env) / audit_log (TOML)
+ * set to a writable file path. No-op otherwise — pre-v3.5.0 users see zero
+ * change.
+ *
+ * Output format: one JSON object per line (JSONL), to make the log greppable
+ * and consumable by log shippers (vector, fluentbit, etc.). Rotation is
+ * intentionally not handled here — use logrotate or equivalent.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { logger } from './logger.js';
+
+// Field names whose values should never appear in the audit log even if a tool
+// somehow passed them through args. Case-insensitive.
+const REDACT_FIELDS = new Set([
+  'password',
+  'passphrase',
+  'sudopassword',
+  'sudo_password',
+  'token',
+  'secret',
+  'apikey',
+  'api_key',
+]);
+
+const REDACTED = '***';
+
+function sanitize(value) {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(sanitize);
+  const out = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (REDACT_FIELDS.has(k.toLowerCase())) {
+      out[k] = REDACTED;
+    } else {
+      out[k] = sanitize(v);
+    }
+  }
+  return out;
+}
+
+let warnedPaths = new Set();
+
+/**
+ * Append one audit line. No-op if the server has no auditLog configured.
+ * Failures are logged but never propagated — auditing must not break tool execution.
+ *
+ * @param {Object} serverConfig
+ * @param {string} toolName
+ * @param {Object} args              - tool arguments (will be sanitized)
+ * @param {Object} policyResult      - { allowed, reason? } from evaluatePolicy
+ * @param {Object} [executionResult] - { code, success, error? } if the tool ran
+ */
+export function auditLog(serverConfig, toolName, args, policyResult, executionResult) {
+  if (!serverConfig || !serverConfig.auditLog) return;
+
+  const auditPath = serverConfig.auditLog;
+  const entry = {
+    ts: new Date().toISOString(),
+    server: serverConfig.name,
+    tool: toolName,
+    args: sanitize(args),
+    allowed: !!policyResult.allowed,
+  };
+  if (policyResult.reason) entry.reason = policyResult.reason;
+  if (executionResult) {
+    if (typeof executionResult.code === 'number') entry.exitCode = executionResult.code;
+    if (typeof executionResult.success === 'boolean') entry.success = executionResult.success;
+    if (executionResult.error) entry.error = String(executionResult.error).slice(0, 500);
+  }
+
+  try {
+    const dir = path.dirname(auditPath);
+    if (dir && dir !== '.' && !fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.appendFileSync(auditPath, JSON.stringify(entry) + '\n', { encoding: 'utf8' });
+  } catch (err) {
+    // Warn once per path, then stay silent to avoid log spam if the path is
+    // permanently broken (e.g. read-only filesystem).
+    if (!warnedPaths.has(auditPath)) {
+      warnedPaths.add(auditPath);
+      logger.warn(
+        `Failed to write audit log for server "${serverConfig.name}" at ${auditPath}: ${err.message} (further failures for this path will be silenced)`
+      );
+    }
+  }
+}
+
+// Exposed for tests.
+export function _resetWarnedPaths() {
+  warnedPaths.clear();
+}

--- a/src/config-loader.js
+++ b/src/config-loader.js
@@ -4,6 +4,33 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { logger } from './logger.js';
+import { VALID_MODES } from './policy.js';
+
+// Parse a `;`-separated list of regex pattern strings. Empty entries are dropped.
+// We do NOT compile here — that happens lazily in policy.js so config-loader stays
+// free of regex error handling.
+function parsePatternList(raw) {
+  if (!raw || typeof raw !== 'string') return [];
+  return raw
+    .split(';')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+// Normalize a mode string. Returns 'unrestricted' for any falsy/unknown input,
+// after logging a warning when the input is set but invalid. This keeps existing
+// configs (no MODE field) on the fast path.
+function normalizeMode(raw, serverName) {
+  if (raw === undefined || raw === null || raw === '') return 'unrestricted';
+  const normalized = String(raw).toLowerCase().trim();
+  if (!VALID_MODES.has(normalized)) {
+    logger.warn(
+      `Unknown security mode "${raw}" for server "${serverName}" — falling back to "unrestricted". Valid: ${[...VALID_MODES].join(', ')}.`
+    );
+    return 'unrestricted';
+  }
+  return normalized;
+}
 
 export class ConfigLoader {
   constructor() {
@@ -81,6 +108,22 @@ export class ConfigLoader {
     if (config.ssh_servers) {
       for (const [name, serverConfig] of Object.entries(config.ssh_servers)) {
         const normalizedName = name.toLowerCase();
+        // allow_patterns / deny_patterns may be either a TOML array of strings
+        // or a single `;`-separated string. Normalize to a string[] of regex
+        // sources — compilation happens in policy.js.
+        const tomlAllow = Array.isArray(serverConfig.allow_patterns)
+          ? serverConfig.allow_patterns
+          : parsePatternList(serverConfig.allow_patterns);
+        const tomlDeny = Array.isArray(serverConfig.deny_patterns)
+          ? serverConfig.deny_patterns
+          : parsePatternList(serverConfig.deny_patterns);
+        const mode = normalizeMode(serverConfig.mode, normalizedName);
+        if (mode === 'restricted' && tomlAllow.length === 0) {
+          logger.warn(
+            `Server "${normalizedName}" is in "restricted" mode but has no allow_patterns — every command will be refused. Set allow_patterns to enable any execution.`
+          );
+        }
+
         this.servers.set(normalizedName, {
           name: normalizedName,
           host: serverConfig.host,
@@ -95,6 +138,10 @@ export class ConfigLoader {
           platform: serverConfig.platform ? serverConfig.platform.toLowerCase() : undefined,
           proxyJump: serverConfig.proxy_jump,
           proxyCommand: serverConfig.proxy_command || serverConfig.proxycommand,
+          mode,
+          allowPatterns: tomlAllow,
+          denyPatterns: tomlDeny,
+          auditLog: serverConfig.audit_log,
           source: 'toml'
         });
       }
@@ -131,6 +178,15 @@ export class ConfigLoader {
         // Skip if already processed from a higher priority source
         if (processedServers.has(serverName)) continue;
 
+        const envAllow = parsePatternList(env[`SSH_SERVER_${match[1]}_ALLOW_PATTERNS`]);
+        const envDeny = parsePatternList(env[`SSH_SERVER_${match[1]}_DENY_PATTERNS`]);
+        const mode = normalizeMode(env[`SSH_SERVER_${match[1]}_MODE`], serverName);
+        if (mode === 'restricted' && envAllow.length === 0) {
+          logger.warn(
+            `Server "${serverName}" is in "restricted" mode but has no SSH_SERVER_${match[1]}_ALLOW_PATTERNS — every command will be refused. Set ALLOW_PATTERNS to enable any execution.`
+          );
+        }
+
         const server = {
           name: serverName,
           host: value,
@@ -145,6 +201,10 @@ export class ConfigLoader {
           platform: (env[`SSH_SERVER_${match[1]}_PLATFORM`] || '').toLowerCase() || undefined,
           proxyJump: env[`SSH_SERVER_${match[1]}_PROXYJUMP`],
           proxyCommand: env[`SSH_SERVER_${match[1]}_PROXYCOMMAND`],
+          mode,
+          allowPatterns: envAllow,
+          denyPatterns: envDeny,
+          auditLog: env[`SSH_SERVER_${match[1]}_AUDIT_LOG`],
           source: 'env'
         };
 
@@ -199,6 +259,16 @@ export class ConfigLoader {
       if (server.platform) serverConfig.platform = server.platform;
       if (server.proxyJump) serverConfig.proxy_jump = server.proxyJump;
       if (server.proxyCommand) serverConfig.proxy_command = server.proxyCommand;
+      // Only emit security fields if they diverge from defaults — keeps generated
+      // TOML files clean for users who never opted in.
+      if (server.mode && server.mode !== 'unrestricted') serverConfig.mode = server.mode;
+      if (server.allowPatterns && server.allowPatterns.length > 0) {
+        serverConfig.allow_patterns = server.allowPatterns;
+      }
+      if (server.denyPatterns && server.denyPatterns.length > 0) {
+        serverConfig.deny_patterns = server.denyPatterns;
+      }
+      if (server.auditLog) serverConfig.audit_log = server.auditLog;
 
       config.ssh_servers[name] = serverConfig;
     }
@@ -229,6 +299,18 @@ export class ConfigLoader {
       if (server.platform) lines.push(`SSH_SERVER_${upperName}_PLATFORM=${server.platform}`);
       if (server.proxyJump) lines.push(`SSH_SERVER_${upperName}_PROXYJUMP=${server.proxyJump}`);
       if (server.proxyCommand) lines.push(`SSH_SERVER_${upperName}_PROXYCOMMAND=${server.proxyCommand}`);
+      // Security fields — only emit when non-default to avoid clutter in
+      // generated .env files for users who never opted in.
+      if (server.mode && server.mode !== 'unrestricted') {
+        lines.push(`SSH_SERVER_${upperName}_MODE=${server.mode}`);
+      }
+      if (server.allowPatterns && server.allowPatterns.length > 0) {
+        lines.push(`SSH_SERVER_${upperName}_ALLOW_PATTERNS="${server.allowPatterns.join(';')}"`);
+      }
+      if (server.denyPatterns && server.denyPatterns.length > 0) {
+        lines.push(`SSH_SERVER_${upperName}_DENY_PATTERNS="${server.denyPatterns.join(';')}"`);
+      }
+      if (server.auditLog) lines.push(`SSH_SERVER_${upperName}_AUDIT_LOG=${server.auditLog}`);
       lines.push('');
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -160,6 +160,8 @@ import {
   getConnectionInfo
 } from './database-manager.js';
 import { loadToolConfig, isToolEnabled } from './tool-config-manager.js';
+import { evaluatePolicy } from './policy.js';
+import { auditLog } from './audit.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -263,6 +265,52 @@ function loadServerConfig() {
   // This function is kept for backward compatibility
   // The actual loading is done by configLoader during initialization
   return servers;
+}
+
+// ── Per-server security policy plumbing (v3.5.0+) ──────────────────────────────
+//
+// Wire any handler that mutates remote state (or executes arbitrary commands)
+// through the helpers below. They are *always* safe to call: for any server
+// without a security mode configured (default `unrestricted`), evaluatePolicy()
+// early-returns { allowed: true } and auditLog() is a no-op when AUDIT_LOG is
+// absent — so pre-v3.5.0 configs see zero behavior change.
+
+function getServerConfig(serverName) {
+  if (!serverName) return null;
+  return servers[String(serverName).toLowerCase()] || null;
+}
+
+// Apply policy + audit a denial in one shot. Returns null when allowed; returns
+// an MCP error response object when denied (handler should `return` it directly).
+function applyServerPolicy(serverName, toolName, args, command) {
+  const serverConfig = getServerConfig(serverName);
+  const policy = evaluatePolicy(serverConfig, toolName, command);
+  if (!policy.allowed) {
+    auditLog(serverConfig, toolName, args, policy);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: formatJSONResponse({
+            server: serverName,
+            tool: toolName,
+            success: false,
+            error: `Policy denied: ${policy.reason}`,
+            code: -2,
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+  return null;
+}
+
+// Convenience for the success-path audit: handlers call this after execution to
+// record the outcome. No-op when AUDIT_LOG is not configured.
+function auditOk(serverName, toolName, args, executionResult) {
+  const serverConfig = getServerConfig(serverName);
+  auditLog(serverConfig, toolName, args, { allowed: true }, executionResult);
 }
 
 // Execute command with timeout - using child_process timeout for real kill
@@ -617,11 +665,16 @@ registerToolConditional(
   async ({ server: serverName, command, cwd, timeout = TIMEOUTS.DEFAULT_COMMAND_TIMEOUT }) => {
     // Cap timeout at maximum allowed
     const cappedTimeout = Math.min(timeout, TIMEOUTS.MAX_COMMAND_TIMEOUT);
+
+    // Expand aliases BEFORE policy evaluation so the user can't bypass a DENY
+    // regex by hiding a destructive command behind an alias.
+    const expandedCommand = expandCommandAlias(command);
+
+    const denied = applyServerPolicy(serverName, 'ssh_execute', { command, cwd }, expandedCommand);
+    if (denied) return denied;
+
     try {
       const ssh = await getConnection(serverName);
-
-      // Expand command aliases
-      const expandedCommand = expandCommandAlias(command);
 
       // Execute hooks for bench commands
       if (expandedCommand.includes('bench update')) {
@@ -672,6 +725,11 @@ registerToolConditional(
       const stdout = truncateOutput(result.stdout);
       const stderr = truncateOutput(result.stderr);
 
+      auditOk(serverName, 'ssh_execute', { command, cwd }, {
+        code: result.code,
+        success: result.code === 0,
+      });
+
       return {
         content: [
           {
@@ -688,6 +746,10 @@ registerToolConditional(
         ],
       };
     } catch (error) {
+      auditOk(serverName, 'ssh_execute', { command, cwd }, {
+        success: false,
+        error: error.message,
+      });
       logger.error('ssh_execute failed', {
         server: serverName,
         error: error.message
@@ -722,6 +784,9 @@ registerToolConditional(
     }
   },
   async ({ server: serverName, localPath, remotePath }) => {
+    const denied = applyServerPolicy(serverName, 'ssh_upload', { localPath, remotePath });
+    if (denied) return denied;
+
     try {
       const ssh = await getConnection(serverName);
 
@@ -737,6 +802,8 @@ registerToolConditional(
         duration: `${Date.now() - startTime}ms`
       });
 
+      auditOk(serverName, 'ssh_upload', { localPath, remotePath }, { success: true });
+
       return {
         content: [
           {
@@ -746,6 +813,10 @@ registerToolConditional(
         ],
       };
     } catch (error) {
+      auditOk(serverName, 'ssh_upload', { localPath, remotePath }, {
+        success: false,
+        error: error.message,
+      });
       logger.logTransfer('upload', serverName, localPath, remotePath, {
         success: false,
         error: error.message
@@ -831,6 +902,9 @@ registerToolConditional(
     }
   },
   async ({ server: serverName, source, destination, exclude = [], dryRun = false, delete: deleteFiles = false, compress = true, verbose = false, checksum = false, timeout = 30000 }) => {
+    const denied = applyServerPolicy(serverName, 'ssh_sync', { source, destination, dryRun, delete: deleteFiles });
+    if (denied) return denied;
+
     try {
       const ssh = await getConnection(serverName);
       const servers = loadServerConfig();
@@ -1596,6 +1670,10 @@ registerToolConditional(
     try {
       const session = getSession(sessionId);
 
+      // Resolve the session's underlying server to its policy.
+      const denied = applyServerPolicy(session.serverName, 'ssh_session_send', { session: sessionId, command }, command);
+      if (denied) return denied;
+
       const startTime = Date.now();
       const result = await session.execute(command, { timeout });
       const duration = Date.now() - startTime;
@@ -1826,6 +1904,15 @@ registerToolConditional(
       const result = await executeOnGroup(
         groupName,
         async (serverName) => {
+          // Per-server policy: each server in the group is evaluated independently.
+          // A server in readonly/restricted mode refuses the command; others
+          // execute normally. Refusal is surfaced as a per-server failure rather
+          // than aborting the whole group (group execution is best-effort).
+          const denied = applyServerPolicy(serverName, 'ssh_execute_group', { group: groupName, command, cwd }, command);
+          if (denied) {
+            const errorText = denied.content?.[0]?.text || 'Policy denied';
+            return { stdout: '', stderr: errorText, code: -2, success: false };
+          }
           const ssh = await getConnection(serverName);
 
           // Build full command with cwd if provided.
@@ -2109,6 +2196,12 @@ registerToolConditional(
     }
   },
   async ({ server, files, options = {} }) => {
+    const denied = applyServerPolicy(server, 'ssh_deploy', {
+      files: files.map((f) => ({ local: f.local, remote: f.remote })),
+      options,
+    });
+    if (denied) return denied;
+
     try {
       const ssh = await getConnection(server);
 
@@ -2205,6 +2298,12 @@ registerToolConditional(
     }
   },
   async ({ server, command, password, cwd, timeout = 30000 }) => {
+    // ssh_execute_sudo is in READONLY_BLOCKED_TOOLS, so readonly mode blocks
+    // it at the tool level. In restricted mode the command itself is matched
+    // against ALLOW/DENY patterns.
+    const denied = applyServerPolicy(server, 'ssh_execute_sudo', { command, cwd }, command);
+    if (denied) return denied;
+
     try {
       const ssh = await getConnection(server);
       const servers = loadServerConfig();
@@ -2902,6 +3001,13 @@ registerToolConditional(
     }
   },
   async ({ action, server, autoAccept = false }) => {
+    // Mutating actions (accept, remove) are blocked in readonly mode at the
+    // tool level. Pure-read actions (verify, list, check) are allowed regardless,
+    // so we only gate when the action would modify state.
+    if (server && (action === 'accept' || action === 'remove')) {
+      const denied = applyServerPolicy(server, 'ssh_key_manage', { action, autoAccept });
+      if (denied) return denied;
+    }
     try {
       const servers = loadServerConfig();
       let resolvedName, serverConfig, host, port;
@@ -3258,6 +3364,9 @@ registerToolConditional(
     }
   },
   async ({ server: serverName, type, name, database, dbUser, dbPassword, dbHost, dbPort, paths, exclude, backupDir, retention = 7, compress = true }) => {
+    const denied = applyServerPolicy(serverName, 'ssh_backup_create', { type, name, database, paths });
+    if (denied) return denied;
+
     try {
       const ssh = await getConnection(serverName);
 
@@ -3542,6 +3651,9 @@ registerToolConditional(
     }
   },
   async ({ server: serverName, backupId, database, dbUser, dbPassword, dbHost, dbPort, targetPath, backupDir }) => {
+    const denied = applyServerPolicy(serverName, 'ssh_backup_restore', { backupId, database, targetPath });
+    if (denied) return denied;
+
     try {
       const ssh = await getConnection(serverName);
       const backupDirectory = backupDir || DEFAULT_BACKUP_DIR;
@@ -3658,6 +3770,9 @@ registerToolConditional(
     }
   },
   async ({ server: serverName, schedule, type, name, database, paths, retention = 7 }) => {
+    const denied = applyServerPolicy(serverName, 'ssh_backup_schedule', { schedule, type, name, database, paths });
+    if (denied) return denied;
+
     try {
       const ssh = await getConnection(serverName);
 
@@ -3957,6 +4072,12 @@ registerToolConditional(
     }
   },
   async ({ server: serverName, action, pid, signal = 'TERM', sortBy = 'cpu', limit = 20, filter }) => {
+    // Only the `kill` action mutates remote state — gate just that branch so
+    // operators on readonly servers can still `list` / `info` processes.
+    if (action === 'kill') {
+      const denied = applyServerPolicy(serverName, 'ssh_process_manager', { action, pid, signal });
+      if (denied) return denied;
+    }
     try {
       const ssh = await getConnection(serverName);
 
@@ -4104,6 +4225,11 @@ registerToolConditional(
     }
   },
   async ({ server: serverName, action, cpuThreshold, memoryThreshold, diskThreshold, enabled = true }) => {
+    // `set` writes config on the remote; `get` and `check` are read-only.
+    if (action === 'set') {
+      const denied = applyServerPolicy(serverName, 'ssh_alert_setup', { action, cpuThreshold, memoryThreshold, diskThreshold, enabled });
+      if (denied) return denied;
+    }
     try {
       const ssh = await getConnection(serverName);
       const configPath = '/etc/ssh-manager-alerts.json';
@@ -4288,6 +4414,9 @@ registerToolConditional(
     }
   },
   async ({ server: serverName, type, database, outputFile, dbUser, dbPassword, dbHost, dbPort, compress = true, tables }) => {
+    const denied = applyServerPolicy(serverName, 'ssh_db_dump', { type, database, outputFile, tables });
+    if (denied) return denied;
+
     try {
       const ssh = await getConnection(serverName);
 
@@ -4399,6 +4528,9 @@ registerToolConditional(
     }
   },
   async ({ server: serverName, type, database, inputFile, dbUser, dbPassword, dbHost, dbPort, drop = true }) => {
+    const denied = applyServerPolicy(serverName, 'ssh_db_import', { type, database, inputFile, drop });
+    if (denied) return denied;
+
     try {
       const ssh = await getConnection(serverName);
 

--- a/src/policy.js
+++ b/src/policy.js
@@ -1,0 +1,247 @@
+/**
+ * Per-server security policy evaluation.
+ *
+ * Three modes, opt-in per server via config (MODE field):
+ *   - "unrestricted" (default): no change vs. pre-v3.5.0 behavior. Early-return.
+ *   - "readonly":   blocks mutating tools entirely; for ssh_execute / ssh_execute_sudo /
+ *                   ssh_execute_group / ssh_session_send, blocks commands matching the
+ *                   built-in destructive denylist below.
+ *   - "restricted": command must match at least one ALLOW_PATTERNS regex AND no
+ *                   DENY_PATTERNS regex. DENY wins over ALLOW.
+ *
+ * Returns { allowed: boolean, reason?: string } — never throws. Callers translate
+ * a refusal into an MCP-level error response.
+ */
+
+import { logger } from './logger.js';
+
+const MODE_UNRESTRICTED = 'unrestricted';
+const MODE_READONLY = 'readonly';
+const MODE_RESTRICTED = 'restricted';
+
+export const VALID_MODES = new Set([MODE_UNRESTRICTED, MODE_READONLY, MODE_RESTRICTED]);
+
+// Tools that mutate remote state and are unconditionally blocked in readonly mode.
+// Read-only tools (ssh_download, ssh_list_servers, ssh_health_check, ssh_db_query, ssh_tail,
+// ssh_monitor, ssh_history, ssh_*_list, ssh_*_status, ssh_db_list) are not listed and
+// pass through.
+export const READONLY_BLOCKED_TOOLS = new Set([
+  'ssh_upload',
+  'ssh_deploy',
+  'ssh_sync',
+  'ssh_execute_sudo',
+  'ssh_backup_create',
+  'ssh_backup_restore',
+  'ssh_backup_schedule',
+  'ssh_db_import',
+  'ssh_db_dump',
+  'ssh_key_manage',
+  'ssh_alert_setup',
+  'ssh_process_manager',
+]);
+
+// Tools whose command argument we want to filter against the readonly built-in
+// denylist and the restricted ALLOW/DENY regexes.
+export const COMMAND_BEARING_TOOLS = new Set([
+  'ssh_execute',
+  'ssh_execute_sudo',
+  'ssh_execute_group',
+  'ssh_session_send',
+]);
+
+// Built-in destructive command regex denylist applied in readonly mode to any
+// command passed to a COMMAND_BEARING_TOOL. Patterns are intentionally simple
+// substring/word matches — not a security boundary, just a guard rail against
+// accidental destructive commands when an operator opts a server into readonly.
+//
+// The user can layer their own DENY_PATTERNS on top via restricted mode for
+// finer control.
+export const READONLY_DENY_REGEX = [
+  /(^|[\s;&|])rm(\s|$)/,
+  /(^|[\s;&|])rmdir(\s|$)/,
+  /(^|[\s;&|])mv(\s|$)/,
+  /(^|[\s;&|])dd(\s|$)/,
+  /(^|[\s;&|])mkfs(\.|\s|$)/,
+  /(^|[\s;&|])chmod(\s|$)/,
+  /(^|[\s;&|])chown(\s|$)/,
+  /(^|[\s;&|])truncate(\s|$)/,
+  /(^|[\s;&|])tee(\s|$)/,
+  /(^|[\s;&|])sudo(\s|$)/,
+  /(^|[\s;&|])su(\s|$)/,
+  /(^|[\s;&|])kill(\s|$)/,
+  /(^|[\s;&|])pkill(\s|$)/,
+  /(^|[\s;&|])killall(\s|$)/,
+  /(^|[\s;&|])shutdown(\s|$)/,
+  /(^|[\s;&|])reboot(\s|$)/,
+  /(^|[\s;&|])halt(\s|$)/,
+  /(^|[\s;&|])poweroff(\s|$)/,
+  /(^|[\s;&|])systemctl\s+(restart|stop|reload|start|enable|disable|mask)/,
+  /(^|[\s;&|])service\s+\S+\s+(restart|stop|reload|start)/,
+  /(^|[\s;&|])docker\s+(rm|stop|restart|kill|prune|system)/,
+  /(^|[\s;&|])apt(-get)?\s+(install|remove|purge|upgrade|update)/,
+  /(^|[\s;&|])yum\s+(install|remove|update|upgrade)/,
+  /(^|[\s;&|])dnf\s+(install|remove|update|upgrade)/,
+  /(^|[\s;&|])pip\s+(install|uninstall)/,
+  /(^|[\s;&|])npm\s+(install|uninstall|publish)/,
+  /(^|[\s;&|])git\s+(reset\s+--hard|push\s+.*--force|clean\s+-fd?)/,
+  />\s*\/(?!dev\/null|dev\/stdout|dev\/stderr|tmp)/, // redirect to non-tmp/non-devnull file
+  />>\s*\/(?!dev\/null|tmp)/,                          // append-redirect to non-tmp file
+  /\|\s*sh(\s|$)/,
+  /\|\s*bash(\s|$)/,
+  /curl\s+[^|]*\|\s*(sh|bash)/,
+  /wget\s+[^|]*\|\s*(sh|bash)/,
+];
+
+/**
+ * Compile a list of regex source strings into RegExp objects.
+ * Invalid regexes are logged and skipped (returned list may be shorter than input).
+ *
+ * @param {string[]} patterns
+ * @param {string} contextLabel - for log messages ("ALLOW" / "DENY")
+ * @param {string} serverName
+ * @returns {RegExp[]}
+ */
+function compilePatterns(patterns, contextLabel, serverName) {
+  const compiled = [];
+  for (const src of patterns) {
+    if (!src || typeof src !== 'string') continue;
+    try {
+      compiled.push(new RegExp(src));
+    } catch (err) {
+      logger.warn(
+        `Invalid ${contextLabel}_PATTERNS regex for server "${serverName}": /${src}/ — ignored (${err.message})`
+      );
+    }
+  }
+  return compiled;
+}
+
+// Per-server compiled-regex cache, keyed by server name. Patterns rarely change at runtime
+// (they're loaded once from config), so this avoids recompiling on every tool call.
+const compiledCache = new Map();
+
+function getCompiledPatterns(serverConfig) {
+  const key = serverConfig.name;
+  const cached = compiledCache.get(key);
+  // Cache invalidation: if the raw pattern strings change, drop the cached entry.
+  if (
+    cached &&
+    cached.allowSrc === (serverConfig.allowPatterns || []).join('') &&
+    cached.denySrc === (serverConfig.denyPatterns || []).join('')
+  ) {
+    return cached;
+  }
+  const allow = compilePatterns(serverConfig.allowPatterns || [], 'ALLOW', key);
+  const deny = compilePatterns(serverConfig.denyPatterns || [], 'DENY', key);
+  const entry = {
+    allow,
+    deny,
+    allowSrc: (serverConfig.allowPatterns || []).join(''),
+    denySrc: (serverConfig.denyPatterns || []).join(''),
+  };
+  compiledCache.set(key, entry);
+  return entry;
+}
+
+/**
+ * Evaluate whether a tool invocation is allowed under the server's policy.
+ *
+ * Performance: in the common case (mode === 'unrestricted' or undefined), this
+ * returns immediately with no allocations beyond the result object.
+ *
+ * @param {Object} serverConfig - the server config object from config-loader.js
+ * @param {string} toolName     - MCP tool name (e.g. "ssh_execute")
+ * @param {string} [command]    - optional command string for COMMAND_BEARING_TOOLS
+ * @returns {{ allowed: boolean, reason?: string }}
+ */
+export function evaluatePolicy(serverConfig, toolName, command) {
+  // Backward-compat fast path: no server config, missing mode, or unrestricted mode
+  // → identical behavior to pre-v3.5.0. Not a single regex is compiled or matched.
+  const mode = serverConfig && serverConfig.mode;
+  if (!mode || mode === MODE_UNRESTRICTED) {
+    return { allowed: true };
+  }
+
+  if (mode === MODE_READONLY) {
+    if (READONLY_BLOCKED_TOOLS.has(toolName)) {
+      return {
+        allowed: false,
+        reason: `Tool "${toolName}" is disabled on server "${serverConfig.name}" (mode: readonly).`,
+      };
+    }
+    if (COMMAND_BEARING_TOOLS.has(toolName) && typeof command === 'string') {
+      for (const re of READONLY_DENY_REGEX) {
+        if (re.test(command)) {
+          return {
+            allowed: false,
+            reason: `Command refused on server "${serverConfig.name}" (mode: readonly): matches built-in destructive pattern ${re}.`,
+          };
+        }
+      }
+    }
+    return { allowed: true };
+  }
+
+  if (mode === MODE_RESTRICTED) {
+    const { allow, deny } = getCompiledPatterns(serverConfig);
+
+    // For non-command-bearing tools in restricted mode, fall back to readonly semantics
+    // (block mutating tools, allow read-only tools). This means restricted mode is a
+    // strict superset of readonly's tool-level blocks plus command-level allowlisting.
+    if (!COMMAND_BEARING_TOOLS.has(toolName)) {
+      if (READONLY_BLOCKED_TOOLS.has(toolName)) {
+        return {
+          allowed: false,
+          reason: `Tool "${toolName}" is disabled on server "${serverConfig.name}" (mode: restricted blocks mutating tools by default).`,
+        };
+      }
+      return { allowed: true };
+    }
+
+    if (typeof command !== 'string') {
+      // Defensive: command-bearing tool called without a command? Refuse.
+      return {
+        allowed: false,
+        reason: `Tool "${toolName}" requires a command argument under restricted mode.`,
+      };
+    }
+
+    for (const re of deny) {
+      if (re.test(command)) {
+        return {
+          allowed: false,
+          reason: `Command refused on server "${serverConfig.name}" (mode: restricted): matches DENY pattern ${re}.`,
+        };
+      }
+    }
+
+    if (allow.length === 0) {
+      return {
+        allowed: false,
+        reason: `Command refused on server "${serverConfig.name}" (mode: restricted): no ALLOW_PATTERNS configured — restricted mode requires an explicit allowlist.`,
+      };
+    }
+
+    for (const re of allow) {
+      if (re.test(command)) {
+        return { allowed: true };
+      }
+    }
+
+    return {
+      allowed: false,
+      reason: `Command refused on server "${serverConfig.name}" (mode: restricted): does not match any ALLOW_PATTERNS.`,
+    };
+  }
+
+  // Unknown mode — fail-closed with a clear message rather than silently allowing.
+  return {
+    allowed: false,
+    reason: `Unknown security mode "${mode}" for server "${serverConfig.name}". Valid: ${[...VALID_MODES].join(', ')}.`,
+  };
+}
+
+// Exposed for tests only.
+export function _clearCompiledCache() {
+  compiledCache.clear();
+}

--- a/tests/test-policy.js
+++ b/tests/test-policy.js
@@ -1,0 +1,298 @@
+/**
+ * Test Suite for Per-Server Security Policy (v3.5.0)
+ *
+ * Validates:
+ *  - unrestricted mode (default + missing) is a strict no-op
+ *  - readonly mode blocks mutating tools and built-in destructive commands
+ *  - restricted mode enforces ALLOW + DENY regex (DENY wins)
+ *  - audit log writes JSONL, sanitizes credentials, is no-op without AUDIT_LOG
+ *  - invalid regex patterns are skipped with a warning, not thrown
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  evaluatePolicy,
+  VALID_MODES,
+  READONLY_BLOCKED_TOOLS,
+  COMMAND_BEARING_TOOLS,
+  _clearCompiledCache,
+} from '../src/policy.js';
+import { auditLog, _resetWarnedPaths } from '../src/audit.js';
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const YELLOW = '\x1b[33m';
+const NC = '\x1b[0m';
+
+let passedTests = 0;
+let failedTests = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`${GREEN}✓${NC} ${name}`);
+    passedTests++;
+  } catch (error) {
+    console.log(`${RED}✗${NC} ${name}`);
+    console.log(`  ${RED}Error: ${error.message}${NC}`);
+    failedTests++;
+  }
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}\n  Expected: ${JSON.stringify(expected)}\n  Actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertTrue(cond, message) {
+  if (!cond) throw new Error(message);
+}
+
+console.log('\n' + YELLOW + 'Running Policy & Audit Tests...' + NC + '\n');
+
+// ── unrestricted (default) ─────────────────────────────────────────────────────
+
+test('No mode → allowed (backward-compat fast path)', () => {
+  const result = evaluatePolicy({ name: 's' }, 'ssh_execute', 'rm -rf /');
+  assertEqual(result.allowed, true, 'A server without a mode field must allow everything');
+});
+
+test('Explicit unrestricted → allowed even for destructive commands', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'unrestricted' }, 'ssh_execute_sudo', 'rm -rf /');
+  assertEqual(result.allowed, true, 'unrestricted is identical to pre-v3.5.0 behavior');
+});
+
+test('null server config → allowed (defensive default)', () => {
+  const result = evaluatePolicy(null, 'ssh_execute', 'ls');
+  assertEqual(result.allowed, true, 'null serverConfig should not crash and should allow');
+});
+
+// ── readonly ───────────────────────────────────────────────────────────────────
+
+test('readonly blocks ssh_upload', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'readonly' }, 'ssh_upload');
+  assertEqual(result.allowed, false, 'ssh_upload must be blocked in readonly');
+  assertTrue(/readonly/.test(result.reason), 'Reason should mention readonly');
+});
+
+test('readonly blocks ssh_execute_sudo', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'readonly' }, 'ssh_execute_sudo', 'whoami');
+  assertEqual(result.allowed, false, 'ssh_execute_sudo is in READONLY_BLOCKED_TOOLS');
+});
+
+test('readonly allows ssh_execute with a safe command', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'readonly' }, 'ssh_execute', 'ls -la /tmp');
+  assertEqual(result.allowed, true, '"ls -la /tmp" is harmless and must pass');
+});
+
+test('readonly refuses ssh_execute with rm', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'readonly' }, 'ssh_execute', 'rm /tmp/foo');
+  assertEqual(result.allowed, false, 'rm matches built-in DENY');
+});
+
+test('readonly refuses chained destructive command', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'readonly' }, 'ssh_execute', 'echo ok && rm /tmp/x');
+  assertEqual(result.allowed, false, 'rm after && must be caught');
+});
+
+test('readonly refuses redirect to system file', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'readonly' }, 'ssh_execute', 'echo bad > /etc/passwd');
+  assertEqual(result.allowed, false, 'Redirect to /etc/* must be caught');
+});
+
+test('readonly allows redirect to /tmp', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'readonly' }, 'ssh_execute', 'echo ok > /tmp/safe');
+  assertEqual(result.allowed, true, 'Redirect to /tmp is whitelisted');
+});
+
+test('readonly refuses curl | sh', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'readonly' }, 'ssh_execute', 'curl https://x | sh');
+  assertEqual(result.allowed, false, 'Pipe to sh must be caught');
+});
+
+test('readonly allows read-only tool (e.g. arbitrary tool not in block list)', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'readonly' }, 'ssh_health_check');
+  assertEqual(result.allowed, true, 'ssh_health_check is not mutant — must be allowed');
+});
+
+// ── restricted ─────────────────────────────────────────────────────────────────
+
+test('restricted with no ALLOW_PATTERNS refuses everything', () => {
+  _clearCompiledCache();
+  const result = evaluatePolicy(
+    { name: 's', mode: 'restricted', allowPatterns: [], denyPatterns: [] },
+    'ssh_execute',
+    'ls'
+  );
+  assertEqual(result.allowed, false, 'No allowlist = fail closed');
+  assertTrue(/no ALLOW_PATTERNS/.test(result.reason), 'Reason should mention missing ALLOW_PATTERNS');
+});
+
+test('restricted: command matches ALLOW_PATTERNS', () => {
+  _clearCompiledCache();
+  const cfg = {
+    name: 's',
+    mode: 'restricted',
+    allowPatterns: ['^docker ps', '^docker logs '],
+    denyPatterns: [],
+  };
+  assertEqual(evaluatePolicy(cfg, 'ssh_execute', 'docker ps').allowed, true, 'docker ps allowed');
+  assertEqual(evaluatePolicy(cfg, 'ssh_execute', 'docker logs my-app').allowed, true, 'docker logs allowed');
+  assertEqual(evaluatePolicy(cfg, 'ssh_execute', 'docker rm xyz').allowed, false, 'docker rm not in allow → refused');
+});
+
+test('restricted: DENY_PATTERNS override ALLOW_PATTERNS', () => {
+  _clearCompiledCache();
+  const cfg = {
+    name: 's',
+    mode: 'restricted',
+    allowPatterns: ['^docker '],
+    denyPatterns: [' rm ', '--force'],
+  };
+  assertEqual(evaluatePolicy(cfg, 'ssh_execute', 'docker ps').allowed, true, 'docker ps still allowed');
+  assertEqual(evaluatePolicy(cfg, 'ssh_execute', 'docker rm x').allowed, false, 'matches DENY pattern');
+  assertEqual(evaluatePolicy(cfg, 'ssh_execute', 'docker logs --force x').allowed, false, '--force is denied');
+});
+
+test('restricted: invalid regex pattern is ignored, valid ones still work', () => {
+  _clearCompiledCache();
+  const cfg = {
+    name: 's',
+    mode: 'restricted',
+    allowPatterns: ['[invalid(', '^ls'],
+    denyPatterns: [],
+  };
+  // The invalid regex is skipped; the valid one still matches "ls".
+  assertEqual(evaluatePolicy(cfg, 'ssh_execute', 'ls -la').allowed, true, 'valid regex still works');
+});
+
+test('restricted: non-command-bearing mutating tool is blocked', () => {
+  _clearCompiledCache();
+  const cfg = {
+    name: 's',
+    mode: 'restricted',
+    allowPatterns: ['^anything'],
+    denyPatterns: [],
+  };
+  assertEqual(evaluatePolicy(cfg, 'ssh_upload').allowed, false, 'restricted inherits readonly blocks');
+});
+
+test('restricted: read-only tool passes through', () => {
+  _clearCompiledCache();
+  const cfg = { name: 's', mode: 'restricted', allowPatterns: ['^x'], denyPatterns: [] };
+  assertEqual(evaluatePolicy(cfg, 'ssh_health_check').allowed, true, 'read-only tools always pass');
+});
+
+// ── unknown mode (fail-closed) ─────────────────────────────────────────────────
+
+test('Unknown mode value → fail-closed with explanatory reason', () => {
+  const result = evaluatePolicy({ name: 's', mode: 'bogus' }, 'ssh_execute', 'ls');
+  assertEqual(result.allowed, false, 'Unknown mode must not silently allow');
+  assertTrue(/Unknown security mode/.test(result.reason), 'Reason should name the issue');
+});
+
+// ── constants integrity ───────────────────────────────────────────────────────
+
+test('VALID_MODES contains exactly the 3 known modes', () => {
+  assertEqual(VALID_MODES.size, 3, 'Should be unrestricted, readonly, restricted');
+  assertTrue(VALID_MODES.has('unrestricted'), 'has unrestricted');
+  assertTrue(VALID_MODES.has('readonly'), 'has readonly');
+  assertTrue(VALID_MODES.has('restricted'), 'has restricted');
+});
+
+test('READONLY_BLOCKED_TOOLS includes core mutators', () => {
+  for (const t of ['ssh_upload', 'ssh_deploy', 'ssh_sync', 'ssh_execute_sudo', 'ssh_backup_create', 'ssh_db_import']) {
+    assertTrue(READONLY_BLOCKED_TOOLS.has(t), `${t} must be in READONLY_BLOCKED_TOOLS`);
+  }
+});
+
+test('COMMAND_BEARING_TOOLS lists exec-style tools', () => {
+  for (const t of ['ssh_execute', 'ssh_execute_sudo', 'ssh_execute_group', 'ssh_session_send']) {
+    assertTrue(COMMAND_BEARING_TOOLS.has(t), `${t} must be in COMMAND_BEARING_TOOLS`);
+  }
+});
+
+// ── audit log ──────────────────────────────────────────────────────────────────
+
+test('auditLog is a no-op when AUDIT_LOG is not configured', () => {
+  // Should not throw, should not create any file
+  auditLog({ name: 's' }, 'ssh_execute', { command: 'ls' }, { allowed: true }, { code: 0, success: true });
+  // No assertion needed: success is "didn't throw and didn't create anything"
+});
+
+test('auditLog writes JSONL when AUDIT_LOG is configured', () => {
+  _resetWarnedPaths();
+  const tmpFile = path.join(os.tmpdir(), `ssh-audit-test-${Date.now()}.log`);
+  try {
+    auditLog(
+      { name: 'prod', auditLog: tmpFile },
+      'ssh_execute',
+      { command: 'ls /tmp' },
+      { allowed: true },
+      { code: 0, success: true }
+    );
+    const content = fs.readFileSync(tmpFile, 'utf8').trim();
+    const lines = content.split('\n');
+    assertEqual(lines.length, 1, 'One audit entry written');
+    const entry = JSON.parse(lines[0]);
+    assertEqual(entry.server, 'prod', 'server field present');
+    assertEqual(entry.tool, 'ssh_execute', 'tool field present');
+    assertEqual(entry.allowed, true, 'allowed field present');
+    assertEqual(entry.exitCode, 0, 'exitCode field present');
+    assertTrue(typeof entry.ts === 'string' && entry.ts.length > 10, 'timestamp present');
+  } finally {
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
+  }
+});
+
+test('auditLog redacts secrets in args', () => {
+  _resetWarnedPaths();
+  const tmpFile = path.join(os.tmpdir(), `ssh-audit-redact-${Date.now()}.log`);
+  try {
+    auditLog(
+      { name: 'prod', auditLog: tmpFile },
+      'ssh_execute_sudo',
+      { command: 'whoami', password: 's3cret', sudoPassword: 'also-secret', nested: { token: 'tok' } },
+      { allowed: true },
+      { code: 0, success: true }
+    );
+    const entry = JSON.parse(fs.readFileSync(tmpFile, 'utf8').trim());
+    assertEqual(entry.args.password, '***', 'password redacted');
+    assertEqual(entry.args.sudoPassword, '***', 'sudoPassword redacted');
+    assertEqual(entry.args.nested.token, '***', 'nested token redacted');
+    assertEqual(entry.args.command, 'whoami', 'non-secret fields preserved');
+  } finally {
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
+  }
+});
+
+test('auditLog records denials with reason', () => {
+  _resetWarnedPaths();
+  const tmpFile = path.join(os.tmpdir(), `ssh-audit-deny-${Date.now()}.log`);
+  try {
+    auditLog(
+      { name: 'prod', auditLog: tmpFile },
+      'ssh_execute',
+      { command: 'rm -rf /' },
+      { allowed: false, reason: 'matches DENY pattern /rm /' }
+    );
+    const entry = JSON.parse(fs.readFileSync(tmpFile, 'utf8').trim());
+    assertEqual(entry.allowed, false, 'allowed=false recorded');
+    assertTrue(/DENY pattern/.test(entry.reason), 'reason recorded');
+  } finally {
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
+  }
+});
+
+// ── summary ───────────────────────────────────────────────────────────────────
+
+console.log('\n' + YELLOW + 'Results:' + NC);
+console.log(`  ${GREEN}Passed: ${passedTests}${NC}`);
+console.log(`  ${RED}Failed: ${failedTests}${NC}\n`);
+
+if (failedTests > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Why

The current authorization model is one layer: client-side `autoApprove` in Claude Code / Codex. It's tool-level and all-or-nothing — once `ssh_execute` is approved, `rm -rf /` runs without a prompt. This makes it risky to share the MCP with a third-party agent, a CI bot, or any other client environment.

This PR adds a **second authorization layer inside the MCP server** that filters tool invocations and commands based on per-server policy. Existing users see **zero behavior change** — every new field is opt-in, every default reproduces v3.4.x exactly.

## What

Three new optional per-server fields:

| `.env` | TOML | Values | Default |
|---|---|---|---|
| `SSH_SERVER_<N>_MODE` | `mode` | `unrestricted` \| `readonly` \| `restricted` | `unrestricted` |
| `SSH_SERVER_<N>_ALLOW_PATTERNS` | `allow_patterns` | `;`-separated regex | (empty) |
| `SSH_SERVER_<N>_DENY_PATTERNS` | `deny_patterns` | `;`-separated regex | (empty) |
| `SSH_SERVER_<N>_AUDIT_LOG` | `audit_log` | file path | (no audit) |

**Modes:**
- `unrestricted` (default) — strict no-op, identical to v3.4.x. `evaluatePolicy()` early-returns on the first line.
- `readonly` — blocks mutating tools (`ssh_upload`, `ssh_deploy`, `ssh_sync`, `ssh_execute_sudo`, `ssh_backup_create/restore/schedule`, `ssh_db_import/dump`, plus action-gated `ssh_key_manage accept|remove`, `ssh_alert_setup set`, `ssh_process_manager kill`) AND applies a built-in denylist on `ssh_execute` (rm, mv, dd, mkfs, chmod, chown, sudo, systemctl restart/stop, docker rm/stop, pipe-to-sh, redirect outside `/tmp`, curl|sh, etc.).
- `restricted` — every command must match at least one `ALLOW_PATTERNS` regex AND no `DENY_PATTERNS` regex. **DENY wins**. With no `ALLOW_PATTERNS` everything is refused (fail-closed).

**Audit log:** opt-in JSONL per server. Records `ts`, `server`, `tool`, `args`, `allowed`, `reason` on denial, `exitCode`/`success`/`error` on execution. Sensitive arg fields (`password`, `passphrase`, `sudoPassword`, `token`, `secret`, `apikey`) are replaced with `***`. No rotation built-in.

**Command aliases** (`ssh_command_alias`) are expanded BEFORE policy evaluation, so a DENY pattern can't be bypassed via an alias.

## Backward compatibility (critical)

The package is on npm and existing configs must keep working untouched.

- No `MODE` field → `mode = 'unrestricted'` → `evaluatePolicy()` returns `{allowed: true}` without compiling a single regex.
- Audit log file is never created unless `AUDIT_LOG` is explicitly set.
- Wizard (`ssh-manager server add`) defaults all three new prompts to "skip" — pressing Enter on each produces an `.env` block identical to v3.4.x.
- Client-side `autoApprove` keeps working — the policy intercepts after the client approves, before SSH runs, so the client never sees a new prompt.
- Pre-existing tests pass unchanged.

## Files

**New:** `src/policy.js`, `src/audit.js`, `tests/test-policy.js`, `docs/SECURITY_MODES.md`, `debug/test-e2e-policy.js`

**Modified:** `src/config-loader.js`, `src/index.js`, `cli/commands/server.sh`, `cli/lib/config.sh`, `package.json`, `README.md`, `CHANGELOG.md`.

## Test plan

- [x] `npm test` — 4 pre-existing suites + new `test:policy` = **39/39 green**
- [x] `npm run test:all` — same + `./scripts/validate.sh` = all green
- [x] `node tests/test-policy.js` — 26 unit tests covering the three modes, DENY > ALLOW precedence, invalid regex handling, redaction, fail-closed for unknown modes, backward-compat fast path
- [x] `debug/test-e2e-policy.js` against a throwaway SSH server (host / user / auth via `SSH_E2E_*` env vars) — 23/23 green