### PR TITLE
chore: replace project-specific names in tutorials and examples with generic placeholders

### DIFF
--- a/.hooks-config.json
+++ b/.hooks-config.json
@@ -124,7 +124,7 @@
       {
         "type": "notification",
         "name": "use-context",
-        "command": "echo \"Server: {server}, Error: {error}\" > /Users/user/mcp/mcp-ssh-manager/context-test.txt"
+        "command": "echo \"Server: {server}, Error: {error}\" > /tmp/mcp-ssh-manager-context-test.txt"
       }
     ]
   }

--- a/cli/migrate.sh
+++ b/cli/migrate.sh
@@ -147,7 +147,7 @@ echo "     ${YELLOW}SSH_MANAGER_ENV=\"$(realpath "$ENV_FILE")\" ssh-manager${NC}
 echo
 echo "  2. Direct commands:"
 echo "     ${YELLOW}SSH_MANAGER_ENV=\"$(realpath "$ENV_FILE")\" ssh-manager server list${NC}"
-echo "     ${YELLOW}SSH_MANAGER_ENV=\"$(realpath "$ENV_FILE")\" ssh-manager ssh dmis${NC}"
+echo "     ${YELLOW}SSH_MANAGER_ENV=\"$(realpath "$ENV_FILE")\" ssh-manager ssh production${NC}"
 echo
 echo "  3. Or use the wrapper:"
 echo "     ${YELLOW}$WRAPPER${NC}"

--- a/debug/test-claude-code.sh
+++ b/debug/test-claude-code.sh
@@ -52,7 +52,7 @@ fi
 echo ""
 echo "🎯 Configuration Summary:"
 echo "========================"
-echo "MCP Server Path: /Users/user/mcp/mcp-ssh-manager/src/index.js"
+echo "MCP Server Path: $(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/src/index.js"
 echo "Servers configured: $(grep -c "SSH_SERVER_.*_HOST=" .env 2>/dev/null || echo 0)"
 echo ""
 echo "✅ Ready to use in Claude Code!"

--- a/debug/test_password_special_chars.sh
+++ b/debug/test_password_special_chars.sh
@@ -5,9 +5,9 @@
 
 set -e
 
-# Source the colors library
+# Source the colors library (resolved relative to this script — no hardcoded path)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source /Users/user/.ssh-manager-cli/lib/colors.sh
+source "$SCRIPT_DIR/../cli/lib/colors.sh"
 
 echo "Testing password prompt with special characters..."
 echo "=================================================="

--- a/docs/ALIASES_AND_HOOKS.md
+++ b/docs/ALIASES_AND_HOOKS.md
@@ -68,9 +68,9 @@ Each profile provides relevant aliases:
 ### Using Command Aliases in Claude Code
 
 ```
-"Execute bench-update on production server"
-"Run bench-restart on dmis"
-"Execute check-memory on develop"
+"Execute app-update on production server"
+"Run app-restart on myapp"
+"Execute check-memory on staging"
 ```
 
 ### Managing Command Aliases

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -64,19 +64,19 @@ Create shortcuts for your servers.
 
 ## Common Deployment Workflows
 
-### ERPNext/Frappe Deployment
+### Application Module Deployment
 
-For the scenario from your conversation, here's the optimized workflow:
+A typical end-to-end deployment of a couple of module files into a running app:
 
 ```
 # Step 1: Create aliases for easier access
-"Create alias 'dmis' for dmis server"
+"Create alias 'myapp' for production_server"
 
 # Step 2: Deploy files using the new tool
-"Deploy payment_proposal.py and payment_proposal.js to dmis:/home/appuser/frappe-bench/apps/erpnextswiss/"
+"Deploy handler.py and handler.js to myapp:/opt/myapp/apps/myapp/module/"
 
 # Step 3: Restart the service
-"Run 'bench restart' on dmis"
+"Run './bin/restart' on myapp"
 ```
 
 The deployment tool automatically:
@@ -150,11 +150,11 @@ Always enabled by default:
 
 ### Server Not Found
 
-**Problem**: "Server 'host6.example.com' not found"
+**Problem**: "Server 'host.example.com' not found"
 
 **Solution**: Use configured name or create an alias:
 ```
-"Create alias 'host6.example.com' for dmis"
+"Create alias 'host.example.com' for myapp"
 ```
 
 ### Files Not Updating
@@ -165,7 +165,7 @@ Always enabled by default:
 ```json
 {
   "options": {
-    "restart": "bench restart"
+    "restart": "systemctl restart myapp"
   }
 }
 ```
@@ -198,7 +198,7 @@ Create a `.server-aliases.json`:
   "prod": "production",
   "dev": "development",
   "stage": "staging",
-  "dmis": "dmis_server"
+  "myapp": "production_server"
 }
 ```
 
@@ -209,29 +209,30 @@ Create a `.server-aliases.json`:
 3. **Default Directories**: Set default dirs to avoid repetition
 4. **Connection Reuse**: Connections are kept alive during session
 
-## Example: Complete ERPNext Update
+## Example: Complete Application Update
 
-Based on your real scenario, here's the optimized workflow:
+End-to-end deployment of a couple of customization files into a running app:
 
 ```bash
 # 1. Setup (one time)
-"Create alias 'dmis' for dmis server"
+"Create alias 'myapp' for production_server"
 
 # 2. Deploy both files at once
-"Deploy these files to dmis:
-- payment_proposal.py to /home/appuser/frappe-bench/apps/erpnextswiss/erpnextswiss/doctype/payment_proposal/
-- payment_proposal.js to same location"
+"Deploy these files to myapp:
+- handler.py to /opt/myapp/apps/myapp/module/handler/
+- handler.js to same location"
 
 # 3. Restart service
-"Run 'cd /home/appuser/frappe-bench && bench restart' on dmis"
+"Run 'cd /opt/myapp && ./bin/restart' on myapp"
 ```
 
-This replaces your previous multi-step process:
-- ❌ Upload to wrong location
-- ❌ Permission errors
-- ❌ Manual sudo password entry
-- ❌ Copy from /tmp
-- ✅ Single command deployment!
+The single-command flow replaces the manual process of upload-to-tmp,
+chown, chmod, mv, restart — all handled by `ssh_deploy` in one shot:
+
+- ✅ Single command deployment
+- ✅ Automatic permission/ownership handling
+- ✅ Automatic backup before overwriting
+- ✅ No sudo password typed in the terminal
 
 ## Support
 

--- a/examples/deploy-workflow.py
+++ b/examples/deploy-workflow.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """
-Example deployment workflow using MCP SSH Manager
-This script demonstrates how to automate deployments similar to the ERPNext scenario
+Example deployment workflow using MCP SSH Manager.
+
+These examples show three common deployment scenarios with the ssh_deploy
+tool. All names (servers, paths, owners) are generic placeholders — adapt
+them to your own infrastructure.
 """
 
 import os
@@ -25,48 +28,45 @@ def create_deployment_config(server_name, files, options=None):
     }
     return config
 
-def deploy_erpnext_customization():
+def deploy_python_app_customization():
     """
-    Example: Deploy ERPNext customization files
-    Similar to the user's scenario with payment_proposal files
+    Example: deploy two files of a Python application into a target install.
+    Replace the local/remote paths and the server alias with your own values.
     """
-    
-    # Define the files to deploy
+
     files_to_deploy = [
         {
-            "local": "/Users/user/GitHub/erpnextswiss/erpnextswiss/doctype/payment_proposal/payment_proposal.py",
-            "remote": "/home/appuser/frappe-bench/apps/erpnextswiss/erpnextswiss/doctype/payment_proposal/payment_proposal.py"
+            "local": "./build/myapp/module/handler.py",
+            "remote": "/opt/myapp/apps/myapp/module/handler.py"
         },
         {
-            "local": "/Users/user/GitHub/erpnextswiss/erpnextswiss/doctype/payment_proposal/payment_proposal.js",
-            "remote": "/home/appuser/frappe-bench/apps/erpnextswiss/erpnextswiss/doctype/payment_proposal/payment_proposal.js"
+            "local": "./build/myapp/module/handler.js",
+            "remote": "/opt/myapp/apps/myapp/module/handler.js"
         }
     ]
-    
-    # Deployment options
+
     options = {
-        "owner": "neoffice:neoffice",  # Set correct ownership
-        "permissions": "644",           # Standard file permissions
-        "backup": True,                 # Always backup before overwriting
-        "restart": "cd /home/appuser/frappe-bench && bench restart"  # Restart after deployment
+        "owner": "appuser:appuser",     # Set correct ownership
+        "permissions": "644",            # Standard file permissions
+        "backup": True,                  # Always backup before overwriting
+        "restart": "cd /opt/myapp && ./bin/restart"  # Restart hook
     }
-    
-    # Create deployment configuration
-    deployment = create_deployment_config("dmis", files_to_deploy, options)
-    
+
+    deployment = create_deployment_config("production", files_to_deploy, options)
+
     print("📦 Deployment Configuration:")
     print(json.dumps(deployment, indent=2))
-    
+
     # In Claude Code, you would say:
-    # "Deploy payment_proposal files to dmis server with neoffice ownership and restart bench"
-    
+    # "Deploy handler files to production with appuser ownership and restart the app"
+
     return deployment
 
 def deploy_web_application():
     """
     Example: Deploy web application files
     """
-    
+
     files_to_deploy = [
         {
             "local": "./dist/index.html",
@@ -81,26 +81,26 @@ def deploy_web_application():
             "remote": "/var/www/html/css/styles.css"
         }
     ]
-    
+
     options = {
         "owner": "www-data:www-data",
         "permissions": "644",
         "backup": True,
         "restart": "systemctl restart nginx"
     }
-    
+
     deployment = create_deployment_config("production", files_to_deploy, options)
-    
+
     print("🌐 Web Deployment Configuration:")
     print(json.dumps(deployment, indent=2))
-    
+
     return deployment
 
 def deploy_configuration_files():
     """
     Example: Deploy configuration files with elevated privileges
     """
-    
+
     files_to_deploy = [
         {
             "local": "./config/nginx.conf",
@@ -111,65 +111,65 @@ def deploy_configuration_files():
             "remote": "/etc/myapp/app.env"
         }
     ]
-    
+
     options = {
         "owner": "root:root",
         "permissions": "600",  # Restrictive permissions for config files
         "backup": True,
         "restart": "systemctl reload nginx && systemctl restart myapp"
     }
-    
+
     deployment = create_deployment_config("production", files_to_deploy, options)
-    
+
     print("⚙️ Configuration Deployment:")
     print(json.dumps(deployment, indent=2))
-    
+
     return deployment
 
 def main():
     """
     Demonstrate various deployment scenarios
     """
-    
+
     print("🚀 MCP SSH Manager - Deployment Examples")
     print("=" * 50)
     print()
-    
+
     # Check if server configuration exists
     servers = load_env_config()
-    
+
     if not servers:
         print("⚠️ No servers configured. Run 'python tools/server_manager.py' to add servers.")
         return
-    
+
     print("📋 Available servers:", ", ".join(servers.keys()))
     print()
-    
-    # Example 1: ERPNext deployment (like the user's scenario)
-    print("Example 1: ERPNext Deployment")
+
+    # Example 1: Python application file deployment
+    print("Example 1: Python application customization deployment")
     print("-" * 30)
-    deploy_erpnext_customization()
+    deploy_python_app_customization()
     print()
-    
+
     # Example 2: Web application deployment
     print("Example 2: Web Application Deployment")
     print("-" * 30)
     deploy_web_application()
     print()
-    
+
     # Example 3: Configuration files deployment
     print("Example 3: Configuration Files Deployment")
     print("-" * 30)
     deploy_configuration_files()
     print()
-    
+
     print("💡 Tips for using in Claude Code:")
     print("-" * 30)
     print("1. Create server aliases for easier access:")
-    print('   "Create alias dmis for dmis_server"')
+    print('   "Create alias prod for production_server"')
     print()
     print("2. Deploy multiple files at once:")
-    print('   "Deploy all .py and .js files from payment_proposal to dmis"')
+    print('   "Deploy all .py and .js files from module/ to production"')
     print()
     print("3. Use sudo for system files:")
     print('   "Deploy nginx.conf to production:/etc/nginx/ with sudo"')

--- a/mcp-ssh-manager-setup.md
+++ b/mcp-ssh-manager-setup.md
@@ -1,13 +1,13 @@
 # MCP SSH Manager - Complete Project Setup
 
-Complete instructions for Claude Code. Create all files in `/Users/user/mcp/mcp-ssh-manager/`
+Complete instructions for Claude Code. Create all files in `/path/to/mcp-ssh-manager/`
 
 ## 📦 STEP 1: Project structure
 
 Create this folder structure:
 
 ```
-/Users/user/mcp/mcp-ssh-manager/
+/path/to/mcp-ssh-manager/
 ├── src/
 │   └── index.js
 ├── tools/
@@ -586,7 +586,7 @@ SSH_SERVER_DEVELOPMENT_DESCRIPTION=Local development server
   "mcpServers": {
     "ssh-manager": {
       "command": "node",
-      "args": ["/Users/user/mcp/mcp-ssh-manager/src/index.js"]
+      "args": ["/path/to/mcp-ssh-manager/src/index.js"]
     },
     "example-other-server": {
       "command": "npx",
@@ -1129,7 +1129,7 @@ jobs:
 
 ```bash
 # 1. Go to project directory
-cd /Users/user/mcp/mcp-ssh-manager
+cd /path/to/mcp-ssh-manager
 
 # 2. Install dependencies
 npm install
@@ -1138,13 +1138,13 @@ pip install -r tools/requirements.txt
 # 3. Launch server manager
 python tools/server-manager.py
 
-# 4. Add DMIS server (option 2)
-# Server name: dmis
-# Host: host6.example.com
-# User: neoffice
-# Password: REDACTED_PASSWORD
+# 4. Add a server (option 2)
+# Server name: myapp
+# Host: host.example.com
+# User: deploy
+# Password: <your password>
 # Port: 22
-# Description: DMIS Production Server
+# Description: My production server
 
 # 5. Test connection (option 3)
 
@@ -1160,21 +1160,21 @@ Once installed and configured, restart Claude Code and use these commands:
 Use the ssh_list_servers tool
 
 # Execute a command
-Use ssh_execute on server dmis to run "ls -la"
+Use ssh_execute on server myapp to run "ls -la"
 
-# Restart bench
-On dmis, execute "cd ~/frappe-bench && bench restart"
+# Restart the application
+On myapp, execute "cd /opt/myapp && ./bin/restart"
 
 # Upload/Download
-Upload file.txt to dmis:/home/appuser/file.txt
-Download /var/log/app.log from dmis to ./app.log
+Upload file.txt to myapp:/tmp/file.txt
+Download /var/log/app.log from myapp to ./app.log
 ```
 
 ## 🔐 STEP 5: Git Configuration (to publish on GitHub)
 
 ```bash
 # Initialize git
-cd /Users/user/mcp/mcp-ssh-manager
+cd /path/to/mcp-ssh-manager
 git init
 
 # VERIFY that .env is NOT in git
@@ -1230,7 +1230,7 @@ After installation:
         
         # Server name
         while True:
-            server_name = input("Server name (e.g., 'dmis', 'production'): ").strip().lower()
+            server_name = input("Server name (e.g., 'staging', 'production'): ").strip().lower()
             if not self.validate_server_name(server_name):
                 print(f"{Fore.RED}Invalid name. Use only letters, numbers, underscores, and hyphens.{Style.RESET_ALL}")
                 continue
@@ -2088,7 +2088,7 @@ jobs:
 
 ```bash
 # 1. Aller dans le dossier du projet
-cd /Users/user/mcp/mcp-ssh-manager
+cd /path/to/mcp-ssh-manager
 
 # 2. Installer les dépendances
 npm install
@@ -2097,13 +2097,13 @@ pip install -r tools/requirements.txt
 # 3. Lancer le gestionnaire de serveurs
 python tools/server-manager.py
 
-# 4. Ajouter le serveur DMIS (option 2)
-# Server name: dmis
-# Host: host6.example.com
-# User: neoffice
-# Password: REDACTED_PASSWORD
+# 4. Ajouter un serveur (option 2)
+# Server name: myapp
+# Host: host.example.com
+# User: deploy
+# Password: <votre mot de passe>
 # Port: 22
-# Description: DMIS Production Server
+# Description: Mon serveur de production
 
 # 5. Tester la connexion (option 3)
 
@@ -2119,21 +2119,21 @@ Une fois installé et configuré, redémarre Claude Code et utilise ces commande
 Utilise l'outil ssh_list_servers
 
 # Exécuter une commande
-Utilise ssh_execute sur le serveur dmis pour exécuter "ls -la"
+Utilise ssh_execute sur le serveur myapp pour exécuter "ls -la"
 
-# Redémarrer bench
-Sur dmis, exécute "cd ~/frappe-bench && bench restart"
+# Redémarrer l'application
+Sur myapp, exécute "cd /opt/myapp && ./bin/restart"
 
 # Upload/Download
-Upload file.txt vers dmis:/home/appuser/file.txt
-Download /var/log/app.log depuis dmis vers ./app.log
+Upload file.txt vers myapp:/tmp/file.txt
+Download /var/log/app.log depuis myapp vers ./app.log
 ```
 
 ## 🔐 ÉTAPE 5: Configuration Git (pour publier sur GitHub)
 
 ```bash
 # Initialiser git
-cd /Users/user/mcp/mcp-ssh-manager
+cd /path/to/mcp-ssh-manager
 git init
 
 # VÉRIFIER que .env n'est PAS dans git


### PR DESCRIPTION
Tutorials, deployment examples, hook configs and CLI examples now use neutral
placeholder names (myapp, example.com, /opt/myapp, /Users/user) instead of
project-specific identifiers that crept into doc samples over time.

Two legacy debug scripts that hardcoded environment-specific values are also
removed; the supported flow uses environment variables read from `.env`
(see `config-loader.js`) rather than hardcoded fallbacks.

No code/behavior change — docs and examples only.