### PR TITLE
fix: exit on stdin EOF / SIGTERM so the stdio server isn't orphaned

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -419,6 +419,11 @@ function setupKeepalive(serverName, ssh) {
     }
   }, KEEPALIVE_INTERVAL);
 
+  // Don't let the keepalive timer keep the process alive on its own. As a stdio
+  // MCP server we must exit when our transport closes; an active interval would
+  // otherwise pin the event loop and leave the process orphaned.
+  if (typeof interval.unref === 'function') interval.unref();
+
   keepaliveIntervals.set(serverName, interval);
 }
 
@@ -4858,15 +4863,44 @@ registerToolConditional(
   }
 );
 
-// Clean up connections on shutdown
-process.on('SIGINT', async () => {
-  console.error('\n🔌 Closing SSH connections...');
+// Clean up connections on shutdown.
+//
+// A stdio MCP server is torn down by its host (e.g. Claude Code) closing our
+// stdin — not by SIGINT, which only arrives on an interactive Ctrl-C. Handling
+// SIGINT alone meant the process was never signalled on normal teardown and was
+// reparented to init as an orphan, leaking one node process per session. Listen
+// for SIGTERM and stdin EOF as well, and make shutdown idempotent so overlapping
+// signals can't double-dispose.
+let isShuttingDown = false;
+function shutdown(reason) {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  console.error(`\n🔌 Closing SSH connections (${reason})...`);
   for (const [name, ssh] of connections) {
-    ssh.dispose();
-    console.error(`  Closed connection to ${name}`);
+    try {
+      ssh.dispose();
+      console.error(`  Closed connection to ${name}`);
+    } catch (error) {
+      console.error(`  Error closing ${name}: ${error.message}`);
+    }
   }
-  process.exit(0);
-});
+  // Best-effort flush of any final stdout the host may still read, but never
+  // hang if it has already stopped reading: a short unref'd timer forces exit
+  // regardless, so this can't reintroduce a stuck process.
+  const force = setTimeout(() => process.exit(0), 250);
+  if (typeof force.unref === 'function') force.unref();
+  process.stdout.write('', () => process.exit(0));
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGHUP', () => shutdown('SIGHUP'));
+// When launched as a stdio MCP server the host closes our stdin to signal
+// teardown; treat that EOF as a shutdown request. 'end' fires when the readable
+// side is fully consumed; 'close' covers the fd being torn down without a clean
+// 'end'. The idempotent guard above makes the overlap harmless.
+process.stdin.on('end', () => shutdown('stdin ended'));
+process.stdin.on('close', () => shutdown('stdin closed'));
 
 // Start the server
 async function main() {
@@ -4883,10 +4917,13 @@ async function main() {
   console.error('💡 Use server-manager.py to configure servers');
   console.error('🔄 Connection management: Auto-reconnect enabled, 30min timeout');
 
-  // Set up periodic cleanup of old connections (every 10 minutes)
-  setInterval(() => {
+  // Set up periodic cleanup of old connections (every 10 minutes).
+  // unref() so this timer alone never keeps the process alive after the
+  // stdio transport has closed.
+  const cleanupTimer = setInterval(() => {
     cleanupOldConnections();
   }, 10 * 60 * 1000);
+  if (typeof cleanupTimer.unref === 'function') cleanupTimer.unref();
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## Problem
Running as a stdio MCP server, `mcp-ssh-manager` is never terminated when the host ends a session: it's reparented to init and leaks. Each orphan holds ~83 MB plus live keepalive timers. They accumulate one-per-session (I found 28 ≈ 2.3 GB after ~1.5 days of normal use).

## Root cause
The only shutdown handler was `process.on('SIGINT')`. A stdio MCP host tears the server down by closing the child's **stdin (EOF)** and/or sending **SIGTERM** — not SIGINT (interactive Ctrl-C only). So normal teardown signalled nothing. The keepalive and 10-min cleanup `setInterval`s are also ref'd, keeping the event loop alive regardless.

## Fix
- Extract shutdown into an **idempotent** `shutdown(reason)` and register it on `SIGTERM`, `SIGHUP`, and stdin `'end'`/`'close'`, in addition to the existing `SIGINT`.
- `.unref()` the per-connection keepalive interval and the periodic cleanup interval, so process lifetime tracks the transport, not a timer.
- Flush stdout best-effort before exiting, guarded by a short `unref`'d timer that forces exit — teardown can never hang if the host has stopped reading.
- Wrap `ssh.dispose()` in try/catch so one bad connection can't block the rest.

## Testing
- `node --check src/index.js` passes.
- **Runtime reproduction, before vs. after.** Booted the server, then closed its stdin to simulate host teardown, measuring time-to-exit:
  - **Before (this revision reverted):** still alive 6000 ms after stdin close (hard-timeout; the orphan bug).
  - **After:** exits cleanly (`code=0`) **11 ms** after stdin close, logging `🔌 Closing SSH connections (stdin ended)...`.
- Static review by a 6-model panel (Opus/Sonnet/Haiku/Grok/Gemini/Codex); their truncation/SIGHUP feedback is folded into this revision.

## Out of scope (follow-up)
`tunnel-manager.js` (`setInterval(monitorTunnels, …)`) and `session-manager.js` have module-level intervals that are also never `unref`'d. The forced exit here makes them harmless for this bug, but they're worth the same treatment in a follow-up.

---
Developed with Claude Code, then reviewed and verified end-to-end on my side: I reproduced the leak, confirmed the root cause in the source, and ran the before/after exit test above. Happy to iterate on anything.
