### PR TITLE
fix(sync): report actual transfer count instead of "no files transferred"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -973,10 +973,8 @@ registerToolConditional(
         rsyncOptions.push('--dry-run');
       }
 
-      if (verbose || logger.verbose) {
-        // Only add stats, not progress to avoid blocking with too much output
-        rsyncOptions.push('--stats');
-      }
+      // Always include --stats so we can parse transfer counts
+      rsyncOptions.push('--stats');
 
       // Add exclude patterns
       exclude.forEach(pattern => {
@@ -1161,9 +1159,11 @@ registerToolConditional(
           };
 
           // Extract statistics from rsync output
-          const filesMatch = output.match(/Number of files transferred: (\d+)/);
-          const sizeMatch = output.match(/Total transferred file size: ([\d,]+) bytes/);
-          const speedMatch = output.match(/([\d.]+) bytes\/sec/);
+          // rsync 2.x: "Number of files transferred: N"
+          // rsync 3.x: "Number of regular files transferred: N"
+          const filesMatch = output.match(/Number of (?:regular )?files transferred: (\d+)/);
+          const sizeMatch = output.match(/Total transferred file size: ([\d,.]+) bytes/);
+          const speedMatch = output.match(/([\d,.]+) bytes\/sec/);
 
           if (filesMatch) stats.filesTransferred = parseInt(filesMatch[1]);
           if (sizeMatch) stats.totalSize = parseInt(sizeMatch[1].replace(/,/g, ''));


### PR DESCRIPTION
## Problem

When AI agents use `ssh_sync`, the tool always reports "No files needed to be transferred" even when files are actually synced. This causes agents to:

- Mistrust the sync result and run redundant verification checks
- Retry the sync unnecessarily, assuming it failed
- Get confused about deployment state and make incorrect decisions

## Root cause

Two issues in rsync output parsing:

1. **`--stats` flag is only added when `verbose` is enabled.** Without it, rsync produces no statistics lines, so the regex match returns `null` and `filesTransferred` stays at `0`, triggering the false "no files" message.

2. **Regex patterns are written for rsync 2.x only.** rsync 3.x (standard on modern distros) changed the output format from `Number of files transferred: N` to `Number of regular files transferred: N`. The old regex misses the word `regular` and never matches.

## Fix

- Always pass `--stats` to rsync regardless of `verbose` setting
- Update regex to handle both rsync 2.x and 3.x output formats:
  - `Number of (regular )?files transferred: N`
  - Accept `.` as thousand separator in size/speed values for locale compatibility

## Verified

Tested live with `ssh_sync` push to a remote server. Before fix: "No files needed to be transferred". After fix: "Files transferred: 1, Total size: 0.04 KB".

<img width="954" height="262" alt="image" src="https://github.com/user-attachments/assets/5fea4cba-4387-40dc-9f48-50d88f1d63c6" />
