### PR TITLE
fix(cli): dynamic version from package.json + ForwardAgent in add wizard

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -69,6 +69,12 @@ echo "Copying CLI files to $CLI_HOME..."
 rm -rf "$CLI_HOME"
 cp -r "$SCRIPT_DIR" "$CLI_HOME"
 
+# Bundle package.json next to the CLI so it can report the real build version
+# (the CLI derives its version from package.json instead of a hardcoded string).
+if [ -f "$SCRIPT_DIR/../package.json" ]; then
+    cp "$SCRIPT_DIR/../package.json" "$CLI_HOME/package.json"
+fi
+
 # Create executable symlink
 $SUDO ln -sf "$CLI_HOME/ssh-manager" "$INSTALL_DIR/ssh-manager"
 

--- a/cli/lib/menu.sh
+++ b/cli/lib/menu.sh
@@ -177,7 +177,17 @@ wizard_add_server() {
     echo "Set a default directory for this server (optional)."
     echo "Example: /var/www/html, /home/user/app, /opt/services"
     prompt_input "Default directory" "" "default_dir"
-    
+
+    local forward_agent="n"
+    echo
+    echo "Forward your local ssh-agent to this server (optional)."
+    echo "Lets remote processes use your local keys — e.g. git over SSH."
+    print_warning "Security: anyone with root on this host can use your loaded keys"
+    print_warning "for the life of the connection. Only enable for servers you trust."
+    if prompt_yes_no "Enable SSH agent forwarding?" "n"; then
+        forward_agent="y"
+    fi
+
     # Step 5: Review
     echo
     print_subheader "Step 5: Review Configuration"
@@ -198,18 +208,27 @@ wizard_add_server() {
     if [ -n "$default_dir" ]; then
         print_table_row "Default Dir:" "$default_dir"
     fi
-    
+    if [ "$forward_agent" = "y" ]; then
+        print_table_row "Agent Forwarding:" "enabled"
+    fi
+
     echo
     if prompt_yes_no "Save this configuration?" "y"; then
         # Save to .env
         add_server_to_env "$server_name" "$host" "$user" "$auth_type" "$auth_value" "$port" "$description"
-        
+
+        local name_upper="$(echo "$server_name" | tr '[:lower:]' '[:upper:]')"
+
         # Add default directory if specified
         if [ -n "$default_dir" ]; then
-            local name_upper="$(echo "$server_name" | tr '[:lower:]' '[:upper:]')"
             echo "SSH_SERVER_${name_upper}_DEFAULT_DIR=$default_dir" >> "$SSH_MANAGER_ENV"
         fi
-        
+
+        # Enable agent forwarding if opted in
+        if [ "$forward_agent" = "y" ]; then
+            echo "SSH_SERVER_${name_upper}_FORWARD_AGENT=true" >> "$SSH_MANAGER_ENV"
+        fi
+
         echo
         print_success "Server '$server_name' added successfully!"
         

--- a/cli/ssh-manager
+++ b/cli/ssh-manager
@@ -21,8 +21,24 @@ source "$SCRIPT_DIR/lib/menu.sh"
 source "$SCRIPT_DIR/commands/server.sh"
 source "$SCRIPT_DIR/commands/tools.sh"
 
-# Version
-VERSION="3.1.0"
+# Version — derived from package.json so it always reflects the real build,
+# never a hardcoded literal that drifts across releases. Works both in-repo
+# (cli/../package.json) and from an installed copy (package.json bundled next
+# to this script by install.sh). Uses sed only, so no jq dependency.
+get_cli_version() {
+    local pkg ver
+    for pkg in "$SCRIPT_DIR/../package.json" "$SCRIPT_DIR/package.json"; do
+        if [ -f "$pkg" ]; then
+            ver="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$pkg" | head -n1)"
+            if [ -n "$ver" ]; then
+                echo "$ver"
+                return
+            fi
+        fi
+    done
+    echo "unknown"
+}
+VERSION="$(get_cli_version)"
 
 # Show version
 show_version() {


### PR DESCRIPTION
## Summary

Two CLI improvements to the interactive `ssh-manager` (bash CLI):

### 1. Version no longer hardcoded
The interactive menu banner was stuck at `VERSION="3.1.0"` — a hardcoded literal the release process never bumped, so it drifted far behind the real package version (now 3.7.0). It's now **derived from `package.json`** (using `sed` only — no `jq` dependency), resolving both:
- **in-repo**: `cli/../package.json`
- **installed copy**: `package.json`, which `install.sh` now bundles next to the CLI

Falls back to `unknown` if no `package.json` is found. Verified live: `ssh-manager --version` now reports `v3.7.0` in both layouts.

### 2. SSH agent forwarding in the "Add server" wizard
Wires the per-server `ForwardAgent` option (added in [#53](https://github.com/bvisible/mcp-ssh-manager/pull/53) / [#52](https://github.com/bvisible/mcp-ssh-manager/issues/52)) into the interactive **Add server** flow — a Step-4 opt-in prompt with the security warning that writes `SSH_SERVER_<NAME>_FORWARD_AGENT=true`. It can now be enabled from the menu instead of only by hand-editing `.env`.

## Verification

- `ssh-manager --version` → `v3.7.0` (in-repo **and** simulated installed layout with bundled `package.json`); `unknown` fallback when absent.
- Drove `wizard_add_server` end-to-end against an isolated `.env` (password auth, forwarding = yes) and confirmed it writes `SSH_SERVER_TESTFA_FORWARD_AGENT=true`, which the loader reads back as `forwardAgent: true`.
- `bash -n` clean on all three touched scripts.

## Known limitation (not addressed here)

The interactive **Edit server** wizard rewrites entries via `update_server_in_env`, which does **not** preserve advanced fields (`forwardAgent`, security `mode`, sudo password, `proxyJump`, `audit_log`) — a pre-existing lossy-edit bug affecting all of them, left for a dedicated follow-up.

## Note for users

The bash CLI is installed as a copy (via `cli/install.sh`), so existing local installs must be **reinstalled** to pick up these changes.